### PR TITLE
GitHub Actions: Test newer Rust and newer deps.

### DIFF
--- a/.github/workflows/aic.yml
+++ b/.github/workflows/aic.yml
@@ -13,6 +13,15 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        include:
+          - toolchain: stable
+            depversions: locked
+          - toolchain: nightly
+            depversions: locked
+          - toolchain: stable
+            depversions: latest
     runs-on: ubuntu-latest
 
     steps:
@@ -21,7 +30,7 @@ jobs:
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
       with:
-          toolchain: stable
+          toolchain: ${{ matrix.toolchain }}
           target: wasm32-unknown-unknown
           override: true
           components: rustfmt, clippy
@@ -30,6 +39,10 @@ jobs:
       run: |
           sudo apt update
           sudo apt-get -y install libxrandr-dev xorg-dev libglfw3-dev 
+    
+    - name: Update dependencies
+      if: ${{ matrix.depversions == 'latest' }}
+      run: cargo update
 
     - uses: Swatinem/rust-cache@v1
 
@@ -44,7 +57,9 @@ jobs:
       run: cargo xtask test-more
     
     # Save wasm build so that we can optionally deploy it without rebuilding
+    # (but only for the stablest matrix version)
     - name: Save wasm dist artifact
+      if: ${{ matrix.toolchain == 'stable' && matrix.depversions == 'locked' }}
       uses: actions/upload-artifact@v2
       with:
         name: wasm-dist

--- a/.github/workflows/aic.yml
+++ b/.github/workflows/aic.yml
@@ -51,10 +51,10 @@ jobs:
       # so that the build of wasm-pack will be cached by rust-cache action.
       run: CARGO_TARGET_DIR=`pwd`/target cargo install wasm-pack
 
-    - name: Build and lint
-      run: cargo xtask lint
     - name: Run tests
       run: cargo xtask test-more
+    - name: Lint
+      run: cargo xtask lint
     
     # Save wasm build so that we can optionally deploy it without rebuilding
     # (but only for the stablest matrix version)


### PR DESCRIPTION
I've occasionally found problems to report with new Rust releases, so building all-is-cubes on nightly seems like a worthwhile idea as a continuous canary.

I also added a mode where the lock file is updated, to catch early when a new allegedly-minor update might have broken something. Someday I might try to get this to work with `minimal-versions`, too!