### PR TITLE
Introduce `Cube` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - `all-is-cubes` library:
+    - `math::Cube` represents a unit cube on the grid; it replaces many previous uses of `GridPoint` to identify cubes.
+
     - `math::Gridgid` represents rigid transformations, a useful subset of what `GridMatrix` already could do.
 
         The following new functions return `Gridgid`:
@@ -18,6 +20,8 @@
     - Block schema and behavior changes:
         - Light emission is now a property of `Atom` blocks instead of `BlockAttributes`.
         - `EvaluatedBlock`’s `color` field is computed more accurately, ignoring voxels hidden by other voxels.
+
+    - All functions manipulating volume data in `Space`, `GridArray`, `Evoxels`, etc. have changed signature to use the new type `math::Cube` instead of `math::GridPoint`.
 
     - The following functions have changed signature to use the new type `math::Gridgid`:
         - `math::GridAab::transform()`
@@ -38,10 +42,13 @@
 ### Removed
 
 - `all-is-cubes` library:
+    - `math::Aab::from_cube()` no longer exists. Use `Cube::aab()` instead.
     - `math::Face7::matrix()` no longer exists. Use `Face6::face_transform()` instead.
     - `math::GridAab::index()` and `contains_cube()` no longer accept `impl Into<GridPoint>`.
-      Call sites should be changed to pass only `GridPoint`.
+      Call sites should be changed to pass only `Cube`.
     - `math::GridRotation::to_positive_octant_matrix()` no longer exists. Use `to_positive_octant_transform()` instead.
+    - `math::cube_to_midpoint()` no longer exists. Use `Cube::midpoint()` instead.
+    - `math::point_to_enclosing_cube()` no longer exists. Use `Cube::containing()` instead.
 
 - `all-is-cubes-mesh` library:
     - `TextureCoordinate` type alias no longer exists.

--- a/all-is-cubes-content/src/animation.rs
+++ b/all-is-cubes-content/src/animation.rs
@@ -10,7 +10,7 @@ use rand_xoshiro::Xoshiro256Plus;
 use all_is_cubes::block::{Block, BlockCollision, AIR};
 use all_is_cubes::cgmath::{EuclideanSpace as _, InnerSpace as _};
 use all_is_cubes::content::palette;
-use all_is_cubes::math::{cube_to_midpoint, GridAab, GridArray, GridPoint, GridVector, Rgba};
+use all_is_cubes::math::{Cube, GridAab, GridArray, GridPoint, GridVector, Rgba};
 use all_is_cubes::space::{Space, SpaceTransaction};
 use all_is_cubes::time::Tick;
 use all_is_cubes::transaction::Merge;
@@ -35,7 +35,7 @@ pub(crate) struct AnimatedVoxels<F> {
     accumulator: Duration,
 }
 
-impl<F: Fn(GridPoint, u64) -> Block + Clone + 'static> AnimatedVoxels<F> {
+impl<F: Fn(Cube, u64) -> Block + Clone + 'static> AnimatedVoxels<F> {
     pub(crate) fn new(function: F) -> Self {
         let frame_period = Duration::from_nanos(1_000_000_000 / 16);
         Self {
@@ -56,7 +56,7 @@ impl<F: Fn(GridPoint, u64) -> Block + Clone + 'static> AnimatedVoxels<F> {
     }
 }
 
-impl<F: Fn(GridPoint, u64) -> Block + Clone + Send + Sync + 'static> behavior::Behavior<Space>
+impl<F: Fn(Cube, u64) -> Block + Clone + Send + Sync + 'static> behavior::Behavior<Space>
     for AnimatedVoxels<F>
 {
     fn step(
@@ -257,8 +257,8 @@ impl Clock {
         let mut txn = SpaceTransaction::default();
         for x in 0..16 {
             for y in 0..16 {
-                let cube = GridPoint::new(x, y, 0);
-                let centered_point = cube_to_midpoint(cube - GridVector::new(8, 8, 0));
+                let cube = Cube::new(x, y, 0);
+                let centered_point = (cube - GridVector::new(8, 8, 0)).midpoint();
                 let r = centered_point.to_vec().magnitude();
                 let block = {
                     let base_angle = centered_point.x.atan2(centered_point.y) / TAU;

--- a/all-is-cubes-content/src/city.rs
+++ b/all-is-cubes-content/src/city.rs
@@ -83,10 +83,10 @@ pub(crate) async fn demo_city(
 
     // Prepare brushes.
     let lamp_brush = VoxelBrush::new([
-        ((0, 0, 0), &demo_blocks[LamppostBase]),
-        ((0, 1, 0), &demo_blocks[LamppostSegment]),
-        ((0, 2, 0), &demo_blocks[LamppostTop]),
-        ((0, 3, 0), &demo_blocks[Lamp]),
+        ([0, 0, 0], &demo_blocks[LamppostBase]),
+        ([0, 1, 0], &demo_blocks[LamppostSegment]),
+        ([0, 2, 0], &demo_blocks[LamppostTop]),
+        ([0, 3, 0], &demo_blocks[Lamp]),
     ]);
 
     // Construct space.
@@ -164,7 +164,7 @@ pub(crate) async fn demo_city(
         let other_side_of_road =
             GridRotation::from_basis([Face6::NX, Face6::PY, Face6::NZ]) * road_aligned_rotation;
         let rotations = [other_side_of_road, road_aligned_rotation];
-        let raycaster = Raycaster::new((0.5, 0.5, 0.5), face.normal_vector::<FreeCoordinate>())
+        let raycaster = Raycaster::new([0.5, 0.5, 0.5], face.normal_vector::<FreeCoordinate>())
             .within(space.bounds());
         let curb_y = GridVector::unit_y();
         for (i, step) in raycaster.enumerate() {

--- a/all-is-cubes-content/src/dungeon/generic.rs
+++ b/all-is-cubes-content/src/dungeon/generic.rs
@@ -3,7 +3,7 @@ use all_is_cubes::util::YieldProgress;
 use all_is_cubes::cgmath::{ElementWise as _, EuclideanSpace as _, Vector3};
 use all_is_cubes::linking::InGenError;
 use all_is_cubes::math::{
-    Face6, FaceMap, GridAab, GridArray, GridCoordinate, GridPoint, GridVector,
+    Cube, Face6, FaceMap, GridAab, GridArray, GridCoordinate, GridPoint, GridVector,
 };
 use all_is_cubes::space::Space;
 
@@ -40,8 +40,11 @@ impl DungeonGrid {
 
     /// Returns the translation which would be applied to move `self.room_box` to the
     /// location of a specific room.
-    pub fn room_translation(&self, room_position: GridPoint) -> GridVector {
-        room_position.to_vec().mul_element_wise(self.room_spacing())
+    pub fn room_translation(&self, room_position: Cube) -> GridVector {
+        room_position
+            .lower_bounds()
+            .to_vec()
+            .mul_element_wise(self.room_spacing())
     }
 
     pub fn room_box_including_walls(&self) -> GridAab {
@@ -49,14 +52,14 @@ impl DungeonGrid {
             .expand(self.room_wall_thickness.map(|_, c| GridCoordinate::from(c)))
     }
 
-    pub fn room_box_at(&self, room_position: GridPoint) -> GridAab {
+    pub fn room_box_at(&self, room_position: Cube) -> GridAab {
         self.room_box
             .translate(self.room_translation(room_position))
     }
 
     /// Returns the volume which lies between two rooms and meets their adjoining faces.
     #[allow(dead_code)] // TODO: superseded in use by theme-specific sizes; review if should keep
-    pub fn shared_wall_at(&self, room_position: GridPoint, face: Face6) -> GridAab {
+    pub fn shared_wall_at(&self, room_position: Cube, face: Face6) -> GridAab {
         self.room_box_at(room_position)
             .abut(
                 face,
@@ -105,7 +108,7 @@ pub trait Theme<R> {
         space: &mut Space,
         pass_index: usize,
         map: &GridArray<R>,
-        position: GridPoint,
+        position_in_room_grid: Cube,
         value: &R,
     ) -> Result<(), InGenError>;
 }

--- a/all-is-cubes-content/src/dungeon/maze.rs
+++ b/all-is-cubes-content/src/dungeon/maze.rs
@@ -1,20 +1,19 @@
 use maze_generator::prelude::{Direction, Field, Maze};
 
-use all_is_cubes::math::{Face6, GridAab, GridArray, GridPoint};
+use all_is_cubes::math::{Cube, Face6, GridAab, GridArray};
 
 pub fn maze_to_array(maze: &Maze) -> GridArray<Field> {
     GridArray::from_fn(
         GridAab::from_lower_size([0, 0, 0], [maze.size.0, 1, maze.size.1]),
-        |p| maze.get_field(&gp2m(p)).unwrap(),
+        |p| maze.get_field(&c2m(p)).unwrap(),
     )
 }
 
-// pub fn m2gp(p: maze_generator::prelude::Coordinates) -> GridPoint {
-//     GridPoint::new(p.x, 0, p.y)
-// }
-
-pub fn gp2m(p: GridPoint) -> maze_generator::prelude::Coordinates {
-    maze_generator::prelude::Coordinates { x: p.x, y: p.z }
+pub fn c2m(cube: Cube) -> maze_generator::prelude::Coordinates {
+    maze_generator::prelude::Coordinates {
+        x: cube.x,
+        y: cube.z,
+    }
 }
 
 pub fn f2d(face: Face6) -> Option<Direction> {

--- a/all-is-cubes-content/src/fractal.rs
+++ b/all-is-cubes-content/src/fractal.rs
@@ -4,7 +4,7 @@ use all_is_cubes::character::Spawn;
 use all_is_cubes::content::free_editing_starter_inventory;
 use all_is_cubes::inv::Tool;
 use all_is_cubes::linking::{BlockProvider, InGenError};
-use all_is_cubes::math::{GridAab, GridCoordinate, GridPoint, GridVector};
+use all_is_cubes::math::{Cube, GridAab, GridCoordinate, GridPoint, GridVector};
 use all_is_cubes::rgba_const;
 use all_is_cubes::space::Space;
 use all_is_cubes::universe::Universe;
@@ -58,16 +58,19 @@ fn visit_menger_sponge_points<E, F>(
     function: &mut F,
 ) -> Result<(), E>
 where
-    F: FnMut(GridPoint) -> Result<(), E>,
+    F: FnMut(Cube) -> Result<(), E>,
 {
     if level == 0 {
-        function(lower_corner)?;
+        function(Cube::from(lower_corner))?;
     } else {
         let size_of_next_level: GridCoordinate = 3_i32.pow((level - 1).into());
         for which_section in pow3aab(1).interior_iter() {
-            let Point3 { x, y, z } = which_section.map(|c| u8::from(c.rem_euclid(2) == 1));
+            let Point3 { x, y, z } = which_section
+                .lower_bounds()
+                .map(|c| u8::from(c.rem_euclid(2) == 1));
             if x + y + z <= 1 {
-                let section_corner = lower_corner + which_section.to_vec() * size_of_next_level;
+                let section_corner =
+                    lower_corner + which_section.lower_bounds().to_vec() * size_of_next_level;
                 visit_menger_sponge_points(level - 1, section_corner, function)?;
             }
         }

--- a/all-is-cubes-content/src/noise.rs
+++ b/all-is-cubes-content/src/noise.rs
@@ -1,8 +1,7 @@
-use all_is_cubes::cgmath::Vector3;
 use noise::NoiseFn;
 
 use all_is_cubes::block::Resolution;
-use all_is_cubes::math::{cube_to_midpoint, GridAab, GridArray, GridPoint};
+use all_is_cubes::math::{Cube, GridAab, GridArray, GridPoint};
 
 /// Generates a [`Block`]-shape of noise values from a [`NoiseFn`].
 ///
@@ -17,18 +16,18 @@ pub(crate) fn array_of_noise<O>(
     mut postprocess: impl FnMut(f64) -> O,
 ) -> GridArray<O> {
     GridArray::from_fn(GridAab::for_block(resolution), |cube| {
-        postprocess(noise_fn.get(cube_to_midpoint(cube).into()))
+        postprocess(noise_fn.get(cube.midpoint().into()))
     })
 }
 
-/// Extension trait for [`noise::NoiseFn`] which makes it usable with our [`GridPoint`]s.
+/// Extension trait for [`noise::NoiseFn`] which makes it usable with our [`Cube`]s.
 pub(crate) trait NoiseFnExt: NoiseFn<f64, 3> {
     /// Sample the noise at the center of the given cube. That is, convert the integer
     /// vector to `f64`, add 0.5 to all coordinates, and call [`NoiseFn::get`].
     ///
     /// This offset is appropriate for the most resolution-independent sampling, or
     /// symmetric shapes with even-numbered widths.
-    fn at_cube(&self, cube: GridPoint) -> f64;
+    fn at_cube(&self, cube: Cube) -> f64;
 
     /// As [`NoiseFn::get`], but converting from integer. Unlike [`NoiseFnExt::at_cube`],
     /// does not apply any offset.
@@ -38,11 +37,11 @@ impl<T> NoiseFnExt for T
 where
     T: NoiseFn<f64, 3> + Sized,
 {
-    fn at_cube(&self, cube: GridPoint) -> f64
+    fn at_cube(&self, cube: Cube) -> f64
     where
         Self: Sized,
     {
-        let point = cube.map(f64::from) + Vector3::new(0.5, 0.5, 0.5);
+        let point = cube.midpoint();
         NoiseFn::get(&self, point.into())
     }
 

--- a/all-is-cubes-content/src/template.rs
+++ b/all-is-cubes-content/src/template.rs
@@ -331,7 +331,7 @@ async fn islands(
 
     for (i, island_pos) in island_grid.interior_iter().enumerate() {
         let cell_bounds = GridAab::from_lower_size(
-            Point3::from_vec(island_pos.to_vec() * island_stride),
+            Point3::from_vec(island_pos.lower_bounds().to_vec() * island_stride),
             [island_stride, island_stride, island_stride],
         )
         .intersection(bounds)

--- a/all-is-cubes-gpu/src/common/debug_lines.rs
+++ b/all-is-cubes-gpu/src/common/debug_lines.rs
@@ -34,11 +34,7 @@ pub(crate) fn gather_debug_lines<V: DebugLineVertex>(
         // This is enabled/disabled inside the lighting algorithm, not as a graphics
         // option.
         for cube in space.last_light_updates.iter().copied() {
-            wireframe_vertices(
-                v,
-                Rgba::new(1.0, 1.0, 0.0, 1.0),
-                &Aab::from_cube(cube).expand(0.005),
-            );
+            wireframe_vertices(v, Rgba::new(1.0, 1.0, 0.0, 1.0), &cube.aab().expand(0.005));
         }
 
         // Lighting trace at cursor

--- a/all-is-cubes-gpu/src/common/octree_alloc.rs
+++ b/all-is-cubes-gpu/src/common/octree_alloc.rs
@@ -1,5 +1,5 @@
 use all_is_cubes::cgmath::EuclideanSpace;
-use all_is_cubes::math::{GridAab, GridCoordinate, GridPoint, GridVector};
+use all_is_cubes::math::{Cube, GridAab, GridCoordinate, GridPoint, GridVector};
 
 /// An octree that knows how to allocate box regions of itself. It stores no other data.
 #[derive(Clone, Debug)]
@@ -244,7 +244,7 @@ impl AlloctreeNode {
                     .filter_map(|(child, child_position)| {
                         child.allocate(
                             size_exponent - 1,
-                            low_corner + child_position.to_vec() * child_size,
+                            low_corner + child_position.lower_bounds().to_vec() * child_size,
                             request,
                         )
                     })
@@ -267,7 +267,7 @@ impl AlloctreeNode {
                 let child_size = expsize(size_exponent - 1);
                 let which_child = relative_low_corner.map(|c| c.div_euclid(child_size));
                 let child_index = GridAab::from_lower_size([0, 0, 0], [2, 2, 2])
-                    .index(which_child)
+                    .index(Cube::from(which_child))
                     .expect("Alloctree::free: out of bounds");
                 children[child_index].free(
                     size_exponent - 1,

--- a/all-is-cubes-gpu/src/in_wgpu/space.rs
+++ b/all-is-cubes-gpu/src/in_wgpu/space.rs
@@ -10,7 +10,7 @@ use all_is_cubes::cgmath::{EuclideanSpace, Point3, Vector3};
 use all_is_cubes::chunking::ChunkPos;
 use all_is_cubes::content::palette;
 use all_is_cubes::listen::{Listen as _, Listener};
-use all_is_cubes::math::{Face6, FaceMap, FreeCoordinate, GridAab, GridCoordinate, GridPoint, Rgb};
+use all_is_cubes::math::{Cube, Face6, FaceMap, FreeCoordinate, GridAab, GridCoordinate, Rgb};
 use all_is_cubes::space::{Space, SpaceChange};
 use all_is_cubes::universe::URef;
 use all_is_cubes_mesh::dynamic::{ChunkedSpaceMesh, RenderDataUpdate};
@@ -592,7 +592,7 @@ struct SpaceRendererTodo {
     /// None means do a full space reupload.
     ///
     /// TODO: experiment with different granularities of light invalidation (chunks, dirty rects, etc.)
-    light: Option<HashSet<GridPoint>>,
+    light: Option<HashSet<Cube>>,
 }
 
 /// [`Listener`] adapter for [`SpaceRendererTodo`].

--- a/all-is-cubes-gpu/src/in_wgpu/vertex.rs
+++ b/all-is-cubes-gpu/src/in_wgpu/vertex.rs
@@ -1,5 +1,5 @@
 use all_is_cubes::cgmath::{Point3, Vector3};
-use all_is_cubes::math::{GridPoint, GridVector};
+use all_is_cubes::math::{Cube, GridVector};
 use all_is_cubes_mesh::{BlockVertex, Coloring, GfxVertex};
 
 use crate::DebugLineVertex;
@@ -125,8 +125,8 @@ impl GfxVertex for WgpuBlockVertex {
     type TexPoint = TexPoint;
 
     #[inline]
-    fn instantiate_block(cube: GridPoint) -> Self::BlockInst {
-        let cube = cube.map(|c| c as u32);
+    fn instantiate_block(cube: Cube) -> Self::BlockInst {
+        let cube = cube.lower_bounds().map(|c| c as u32);
         cube.x | (cube.y << 8) | (cube.z << 16)
     }
 
@@ -246,7 +246,7 @@ mod tests {
             face: Face6::PX,
             coloring: Coloring::Solid(Rgba::new(0.0, 0.5, 1.0, 0.5)),
         });
-        vertex.instantiate_vertex(WgpuBlockVertex::instantiate_block(Point3::new(100, 50, 7)));
+        vertex.instantiate_vertex(WgpuBlockVertex::instantiate_block(Cube::new(100, 50, 7)));
         assert_eq!(GfxVertex::position(&vertex), Point3::new(100.25, 50.0, 8.0));
     }
 }

--- a/all-is-cubes-mesh/src/block_mesh.rs
+++ b/all-is-cubes-mesh/src/block_mesh.rs
@@ -6,10 +6,10 @@ use std::fmt::Debug;
 
 use all_is_cubes::block::{AnimationChange, EvaluatedBlock, Evoxel, Evoxels, Resolution};
 use all_is_cubes::camera::Flaws;
-use all_is_cubes::cgmath::{Point2, Point3};
+use all_is_cubes::cgmath::Point2;
 use all_is_cubes::math::{
-    Face6, Face7, FaceMap, FreeCoordinate, GridAab, GridArray, GridCoordinate, OpacityCategory,
-    Rgba,
+    Cube, Face6, Face7, FaceMap, FreeCoordinate, GridAab, GridArray, GridCoordinate,
+    OpacityCategory, Rgba,
 };
 use all_is_cubes::space::Space;
 
@@ -390,8 +390,8 @@ where
 
                         for t in rotated_voxel_range.y_range() {
                             for s in rotated_voxel_range.x_range() {
-                                let cube: Point3<GridCoordinate> =
-                                    voxel_transform.transform_cube(Point3::new(s, t, layer));
+                                let cube: Cube =
+                                    voxel_transform.transform_cube(Cube::new(s, t, layer));
 
                                 let color = options.transparency.limit_alpha(
                                     voxels_array.get(cube).unwrap_or(&Evoxel::AIR).color,
@@ -617,8 +617,6 @@ mod tests {
     use crate::Coloring;
     use all_is_cubes::block::{Block, AIR};
     use all_is_cubes::camera::GraphicsOptions;
-    use all_is_cubes::cgmath::EuclideanSpace;
-    use all_is_cubes::math::GridPoint;
     use all_is_cubes::universe::Universe;
 
     type TestMesh = BlockMesh<BlockVertex<NoTexture>, NoTexture>;
@@ -653,7 +651,7 @@ mod tests {
         // Define a block which has only solid colored faces, so gets vertex colors
         let block = Block::builder()
             .voxels_fn(&mut universe, Resolution::R2, |cube| {
-                if cube == GridPoint::origin() {
+                if cube == Cube::ORIGIN {
                     AIR
                 } else {
                     Block::from(Rgba::WHITE)

--- a/all-is-cubes-mesh/src/block_vertex.rs
+++ b/all-is-cubes-mesh/src/block_vertex.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 
 use all_is_cubes::cgmath::{EuclideanSpace as _, Point3, Vector3};
-use all_is_cubes::math::{Face6, FreeCoordinate, GridPoint, Rgba};
+use all_is_cubes::math::{Cube, Face6, FreeCoordinate, Rgba};
 use all_is_cubes::util::{ConciseDebug, CustomFormat};
 
 /// Basic vertex data type for a [`BlockMesh`].
@@ -138,7 +138,7 @@ pub trait GfxVertex: From<BlockVertex<Self::TexPoint>> + Copy + Sized + 'static 
     /// Prepare the information needed by [`Self::instantiate_vertex()`] for one block.
     /// Currently, this constitutes the location of that block, and hence this function
     /// is responsible for any necessary numeric conversion.
-    fn instantiate_block(cube: GridPoint) -> Self::BlockInst;
+    fn instantiate_block(cube: Cube) -> Self::BlockInst;
 
     /// Transforms a vertex belonging to a general model of a block to its instantiation
     /// in a specific location in space.
@@ -164,8 +164,8 @@ impl<T: Copy + 'static> GfxVertex for BlockVertex<T> {
     }
 
     #[inline]
-    fn instantiate_block(cube: GridPoint) -> Self::BlockInst {
-        cube.to_vec().map(FreeCoordinate::from)
+    fn instantiate_block(cube: Cube) -> Self::BlockInst {
+        cube.lower_bounds().to_vec().map(FreeCoordinate::from)
     }
 
     #[inline]

--- a/all-is-cubes-mesh/src/dynamic/chunked_mesh/tests.rs
+++ b/all-is-cubes-mesh/src/dynamic/chunked_mesh/tests.rs
@@ -7,7 +7,7 @@ use all_is_cubes::camera::{Camera, Flaws, GraphicsOptions, TransparencyOption, V
 use all_is_cubes::cgmath::{EuclideanSpace as _, Point3};
 use all_is_cubes::chunking::ChunkPos;
 use all_is_cubes::listen::Listener as _;
-use all_is_cubes::math::{FreeCoordinate, GridAab, GridCoordinate};
+use all_is_cubes::math::{Cube, FreeCoordinate, GridAab, GridCoordinate};
 use all_is_cubes::math::{GridPoint, NotNan};
 use all_is_cubes::space::{Space, SpaceChange, SpaceTransaction};
 use all_is_cubes::universe::{URef, Universe};
@@ -43,7 +43,7 @@ fn update_adjacent_chunk_positive() {
         (ChunkPos::new(0, 0, 0), ChunkTodo::CLEAN),
         (ChunkPos::new(1, 0, 0), ChunkTodo::CLEAN),
     ]);
-    listener.receive(SpaceChange::Block(GridPoint::new(
+    listener.receive(SpaceChange::Block(Cube::new(
         CHUNK_SIZE - 1,
         CHUNK_SIZE / 2,
         CHUNK_SIZE / 2,
@@ -79,7 +79,7 @@ fn update_adjacent_chunk_negative() {
         (ChunkPos::new(0, 0, 0), ChunkTodo::CLEAN),
         (ChunkPos::new(1, 0, 0), ChunkTodo::CLEAN),
     ]);
-    listener.receive(SpaceChange::Block(GridPoint::new(
+    listener.receive(SpaceChange::Block(Cube::new(
         0,
         CHUNK_SIZE / 2,
         CHUNK_SIZE / 2,
@@ -111,7 +111,7 @@ fn todo_ignores_absent_chunks() {
     let todo: Arc<Mutex<CsmTodo<CHUNK_SIZE>>> = Default::default();
     let listener = TodoListener(Arc::downgrade(&todo));
 
-    let p = GridPoint::new(1, 1, 1) * (CHUNK_SIZE / 2);
+    let p = Cube::from(GridPoint::new(1, 1, 1) * (CHUNK_SIZE / 2));
     // Nothing happens...
     listener.receive(SpaceChange::Block(p));
     assert_eq!(read_todo_chunks(&todo), vec![]);

--- a/all-is-cubes-mesh/src/space_mesh.rs
+++ b/all-is-cubes-mesh/src/space_mesh.rs
@@ -6,7 +6,7 @@ use ordered_float::OrderedFloat;
 
 use all_is_cubes::camera::Flaws;
 use all_is_cubes::cgmath::{EuclideanSpace as _, MetricSpace as _, Point3, Vector3, Zero as _};
-use all_is_cubes::math::{Face6, GridAab, GridCoordinate, GridPoint, GridRotation};
+use all_is_cubes::math::{Cube, Face6, GridAab, GridCoordinate, GridRotation};
 use all_is_cubes::space::{BlockIndex, Space};
 
 use crate::texture;
@@ -435,7 +435,7 @@ impl<V, T> std::ops::Deref for SpaceMesh<V, T> {
 ///   make no difference.
 fn write_block_mesh_to_space_mesh<V: GfxVertex, T: texture::Tile>(
     block_mesh: &BlockMesh<V, T>,
-    cube: GridPoint,
+    cube: Cube,
     vertices: &mut Vec<V>,
     opaque_indices: &mut IndexVec,
     transparent_indices: &mut IndexVec,
@@ -538,7 +538,7 @@ impl<V: GfxVertex, T: texture::Tile> From<&BlockMesh<V, T>> for SpaceMesh<V, T> 
         );
         write_block_mesh_to_space_mesh(
             block_mesh,
-            GridPoint::origin(),
+            Cube::ORIGIN,
             &mut space_mesh.vertices,
             &mut space_mesh.indices,
             &mut transparent_indices,
@@ -821,7 +821,7 @@ mod tests {
     use crate::texture::{TestPoint, TestTile};
     use crate::{tests::mesh_blocks_and_space, BlockVertex};
     use all_is_cubes::block::Block;
-    use all_is_cubes::math::{GridPoint, Rgba};
+    use all_is_cubes::math::Rgba;
     use std::mem;
 
     type TestMesh = SpaceMesh<BlockVertex<TestPoint>, TestTile>;
@@ -839,7 +839,7 @@ mod tests {
 
     #[test]
     fn nonempty_properties() {
-        let space = Space::builder(GridAab::single_cube(GridPoint::origin()))
+        let space = Space::builder(GridAab::ORIGIN_CUBE)
             .filled_with(Block::from(Rgba::WHITE))
             .build();
         let (_, _, mesh) = mesh_blocks_and_space(&space);

--- a/all-is-cubes-mesh/src/tests.rs
+++ b/all-is-cubes-mesh/src/tests.rs
@@ -1,6 +1,6 @@
 //! Tests for [`crate::mesh`].
 
-use all_is_cubes::math::Rgb;
+use all_is_cubes::math::{Cube, Rgb};
 use pretty_assertions::assert_eq;
 
 use all_is_cubes::block::{
@@ -11,7 +11,7 @@ use all_is_cubes::cgmath::{MetricSpace as _, Point3, Transform as _, Vector3};
 use all_is_cubes::content::{make_some_blocks, make_some_voxel_blocks};
 use all_is_cubes::math::{
     Face6::{self, *},
-    FaceMap, FreeCoordinate, GridAab, GridPoint, GridRotation, Rgba,
+    FaceMap, FreeCoordinate, GridAab, GridRotation, Rgba,
 };
 use all_is_cubes::space::{Space, SpacePhysics};
 use all_is_cubes::universe::Universe;
@@ -88,7 +88,7 @@ pub(crate) fn mesh_blocks_and_space(
     (tex, block_meshes, space_mesh)
 }
 
-fn non_uniform_fill(cube: GridPoint) -> &'static Block {
+fn non_uniform_fill(cube: Cube) -> &'static Block {
     // TODO: This should be simple to write, such as by having a simple owned const constructor from colors
     const C1: &Primitive = &Primitive::Atom(Atom {
         attributes: BlockAttributes::default(),
@@ -149,7 +149,7 @@ fn no_panic_on_missing_blocks() {
     );
     assert_eq!(block_meshes.len(), 1); // check our assumption
 
-    space.set((0, 0, 0), &block).unwrap(); // render data does not know about this
+    space.set([0, 0, 0], &block).unwrap(); // render data does not know about this
 
     // This should not panic; visual glitches are preferable to failure.
     let space_mesh = SpaceMesh::new(
@@ -177,12 +177,12 @@ fn trivial_voxels_equals_atom() {
 
     let (_, _, space_rendered_a) = mesh_blocks_and_space(&{
         let mut space = Space::empty_positive(1, 1, 1);
-        space.set((0, 0, 0), &atom_block).unwrap();
+        space.set([0, 0, 0], &atom_block).unwrap();
         space
     });
     let (tex, _, space_rendered_r) = mesh_blocks_and_space(&{
         let mut space = Space::empty_positive(1, 1, 1);
-        space.set((0, 0, 0), &trivial_recursive_block).unwrap();
+        space.set([0, 0, 0], &trivial_recursive_block).unwrap();
         space
     });
 
@@ -211,7 +211,7 @@ fn space_mesh_equals_block_mesh() {
         .unwrap()
         .build();
     let mut outer_space = Space::empty_positive(1, 1, 1);
-    outer_space.set((0, 0, 0), &recursive_block).unwrap();
+    outer_space.set([0, 0, 0], &recursive_block).unwrap();
 
     let (tex, block_meshes, space_rendered) = mesh_blocks_and_space(&outer_space);
 
@@ -243,7 +243,7 @@ fn block_resolution_greater_than_tile() {
         .unwrap()
         .build();
     let mut outer_space = Space::empty_positive(1, 1, 1);
-    outer_space.set((0, 0, 0), &block).unwrap();
+    outer_space.set([0, 0, 0], &block).unwrap();
 
     let (_, _, _) = mesh_blocks_and_space(&outer_space);
     // TODO: Figure out how to make a useful assert. At least this is "it doesn't panic".
@@ -268,7 +268,7 @@ fn shrunken_box_has_no_extras() {
         .unwrap()
         .build();
     let mut outer_space = Space::empty_positive(1, 1, 1);
-    outer_space.set((0, 0, 0), &less_than_full_block).unwrap();
+    outer_space.set([0, 0, 0], &less_than_full_block).unwrap();
 
     let (tex, _, space_rendered) = mesh_blocks_and_space(&outer_space);
 
@@ -330,7 +330,7 @@ fn shrunken_box_uniform_color() {
         .unwrap()
         .build();
     let mut outer_space = Space::empty_positive(1, 1, 1);
-    outer_space.set((0, 0, 0), &less_than_full_block).unwrap();
+    outer_space.set([0, 0, 0], &less_than_full_block).unwrap();
 
     let (tex, _, space_rendered) = mesh_blocks_and_space(&outer_space);
 
@@ -516,7 +516,7 @@ fn handling_allocation_failure() {
     let block_derived_color = complex_block.evaluate().unwrap().color;
 
     let mut space = Space::empty_positive(1, 1, 1);
-    space.set((0, 0, 0), &complex_block).unwrap();
+    space.set([0, 0, 0], &complex_block).unwrap();
 
     let mut tex = TestAllocator::new();
     tex.set_capacity(0);

--- a/all-is-cubes-mesh/src/texture.rs
+++ b/all-is-cubes-mesh/src/texture.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use all_is_cubes::block::{Evoxel, Evoxels};
 use all_is_cubes::cgmath::Point3;
 use all_is_cubes::content::palette;
-use all_is_cubes::math::{GridAab, GridPoint};
+use all_is_cubes::math::{Cube, GridAab};
 use all_is_cubes::util::{ConciseDebug, CustomFormat};
 
 #[cfg(doc)]
@@ -173,7 +173,7 @@ pub(super) fn copy_voxels_into_existing_texture<T: Tile>(voxels: &Evoxels, textu
             for x in bounds.x_range() {
                 texels.push(
                     voxels
-                        .get(GridPoint { x, y, z })
+                        .get(Cube { x, y, z })
                         .unwrap_or(Evoxel::from_color(palette::MISSING_VOXEL_FALLBACK))
                         .color
                         .to_srgb8(),

--- a/all-is-cubes-port/src/gltf/mesh.rs
+++ b/all-is-cubes-port/src/gltf/mesh.rs
@@ -267,7 +267,7 @@ mod tests {
     fn no_extra_indices_when_transparent() {
         let mut space = Space::empty_positive(1, 1, 1);
         space
-            .set((0, 0, 0), &Block::from(Rgba::new(0., 0., 0., 0.5)))
+            .set([0, 0, 0], &Block::from(Rgba::new(0., 0., 0., 0.5)))
             .unwrap();
 
         let mut writer = GltfWriter::new(GltfDataDestination::null());

--- a/all-is-cubes-port/src/gltf/tests.rs
+++ b/all-is-cubes-port/src/gltf/tests.rs
@@ -48,7 +48,7 @@ fn gltf_smoke_test() {
         .unwrap()
         .build();
     let mut outer_space = Space::empty_positive(1, 1, 1);
-    outer_space.set((0, 0, 0), &recursive_block).unwrap();
+    outer_space.set([0, 0, 0], &recursive_block).unwrap();
 
     let mut writer = GltfWriter::new(GltfDataDestination::null());
     let (_, mesh_index) = gltf_mesh(&outer_space, &mut writer);

--- a/all-is-cubes-port/src/gltf/texture.rs
+++ b/all-is-cubes-port/src/gltf/texture.rs
@@ -250,6 +250,8 @@ pub(super) fn insert_block_texture_atlas(
 }
 
 mod internal {
+    use all_is_cubes::math::Cube;
+
     use super::*;
     use std::collections::BTreeMap;
     use std::mem;
@@ -351,11 +353,12 @@ mod internal {
                         // Zero-offset position in the rotated-to-flat slice.
                         let pixel_position = Point3::new(x, y, 0).cast::<i32>().unwrap();
                         // Position in the rotated-to-flat slice's coordinates.
-                        let position_in_rotated_slice =
-                            pixel_position + rotated_slice_bounds.lower_bounds().to_vec();
+                        let position_in_rotated_slice = Cube::from(
+                            pixel_position + rotated_slice_bounds.lower_bounds().to_vec(),
+                        );
                         // TODO: this single cube is a kludge to simplify off-by-1 problems with rotation
                         // We should have transform helpers instead of computing twice as many coordinates.
-                        let cube_in_rotated_slice = GridAab::single_cube(position_in_rotated_slice);
+                        let cube_in_rotated_slice = position_in_rotated_slice.grid_aab();
 
                         // Position in the original requested slice's coordinates.
                         let unrotated = cube_in_rotated_slice.transform(unrotate.into()).unwrap();

--- a/all-is-cubes-port/src/gltf/vertex.rs
+++ b/all-is-cubes-port/src/gltf/vertex.rs
@@ -1,7 +1,7 @@
 //! [`GltfVertex`], vertex type for writing to glTF buffers.
 
 use all_is_cubes::cgmath::{EuclideanSpace as _, Point3, Vector3};
-use all_is_cubes::math::GridPoint;
+use all_is_cubes::math::Cube;
 use all_is_cubes_mesh::{BlockVertex, Coloring, GfxVertex};
 
 use super::glue::Lef32;
@@ -89,8 +89,8 @@ impl GfxVertex for GltfVertex {
     type TexPoint = GltfAtlasPoint;
 
     #[inline]
-    fn instantiate_block(cube: GridPoint) -> Self::BlockInst {
-        cube.to_vec().map(|s| s as f32)
+    fn instantiate_block(cube: Cube) -> Self::BlockInst {
+        cube.lower_bounds().to_vec().map(|s| s as f32)
     }
 
     #[inline]

--- a/all-is-cubes-port/src/mv.rs
+++ b/all-is-cubes-port/src/mv.rs
@@ -5,7 +5,7 @@ use all_is_cubes::cgmath::{EuclideanSpace as _, Point3, Vector3};
 use all_is_cubes::character::{Character, Spawn};
 use all_is_cubes::content::free_editing_starter_inventory;
 use all_is_cubes::linking::InGenError;
-use all_is_cubes::math::{GridAab, GridCoordinate, GridRotation, GridVector, Gridgid, Rgb, Rgba};
+use all_is_cubes::math::{Cube, GridAab, GridRotation, GridVector, Gridgid, Rgb, Rgba};
 use all_is_cubes::space::{LightPhysics, SetCubeError, Space};
 use all_is_cubes::universe::{self, Name, PartialUniverse, Universe};
 use all_is_cubes::util::{ConciseDebug, CustomFormat, YieldProgress};
@@ -182,12 +182,14 @@ fn dot_vox_model_to_space(
         .build();
 
     for v in model.voxels.iter() {
-        let converted_cube: Point3<GridCoordinate> = Point3 {
-            x: v.x,
-            y: v.y,
-            z: v.z,
-        }
-        .map(i32::from);
+        let converted_cube: Cube = Cube::from(
+            Point3 {
+                x: v.x,
+                y: v.y,
+                z: v.z,
+            }
+            .map(i32::from),
+        );
         let transformed_cube = transform.transform_cube(converted_cube);
 
         #[allow(clippy::unnecessary_lazy_evaluations)] // dubious positive
@@ -324,7 +326,6 @@ fn aic_to_mv_coordinate_transform(aic_bounds: GridAab) -> Gridgid {
 mod tests {
     use super::*;
     use all_is_cubes::block::BlockDef;
-    use all_is_cubes::math::GridPoint;
     use all_is_cubes::raytracer::print_space;
     use all_is_cubes::universe::URef;
     use either::Either;
@@ -351,8 +352,8 @@ mod tests {
         });
 
         assert_eq!(
-            t.transform_cube(GridPoint::new(10, 20, 30)),
-            GridPoint::new(10, 30, 179)
+            t.transform_cube(Cube::new(10, 20, 30)),
+            Cube::new(10, 30, 179)
         );
 
         assert_eq!(

--- a/all-is-cubes-ui/src/logo.rs
+++ b/all-is-cubes-ui/src/logo.rs
@@ -24,11 +24,11 @@ pub fn logo_text() -> Arc<dyn vui::Widget> {
         font: || &FONT_9X15_BOLD,
         brush: {
             VoxelBrush::new([
-                ((0, 0, 1), foreground_text_block),
-                ((1, 0, 0), background_text_block.clone()),
-                ((-1, 0, 0), background_text_block.clone()),
-                ((0, 1, 0), background_text_block.clone()),
-                ((0, -1, 0), background_text_block),
+                ([0, 0, 1], foreground_text_block),
+                ([1, 0, 0], background_text_block.clone()),
+                ([-1, 0, 0], background_text_block.clone()),
+                ([0, 1, 0], background_text_block.clone()),
+                ([0, -1, 0], background_text_block),
             ])
         },
         text_style: TextStyleBuilder::new()

--- a/all-is-cubes-ui/src/vui/page.rs
+++ b/all-is-cubes-ui/src/vui/page.rs
@@ -51,8 +51,8 @@ impl UiSize {
     /// TODO: depth should be up to the choice of the individual pages.
     pub(crate) fn space_bounds(&self) -> GridAab {
         GridAab::from_lower_upper(
-            (0, 0, -Self::DEPTH_BEHIND_VIEW_PLANE),
-            (self.size.x, self.size.y, 5),
+            [0, 0, -Self::DEPTH_BEHIND_VIEW_PLANE],
+            [self.size.x, self.size.y, 5],
         )
     }
 

--- a/all-is-cubes-ui/src/vui/widgets.rs
+++ b/all-is-cubes-ui/src/vui/widgets.rs
@@ -46,11 +46,7 @@ impl vui::WidgetController for OneshotController {
 /// A block may act as a 1×1×1 non-interactive widget.
 impl vui::Widget for Block {
     fn controller(self: Arc<Self>, grant: &vui::LayoutGrant) -> Box<dyn vui::WidgetController> {
-        let cube = grant
-            .shrink_to(GridVector::new(1, 1, 1), false)
-            .bounds
-            .lower_bounds();
-        OneshotController::new(if grant.bounds.contains_cube(cube) {
+        OneshotController::new(if let Some(cube) = grant.shrink_to_cube() {
             SpaceTransaction::set_cube(cube, None, Some(Block::clone(&self)))
         } else {
             SpaceTransaction::default()

--- a/all-is-cubes-ui/src/vui/widgets/crosshair.rs
+++ b/all-is-cubes-ui/src/vui/widgets/crosshair.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use all_is_cubes::block::{Block, AIR};
 use all_is_cubes::listen::{DirtyFlag, ListenableSource};
-use all_is_cubes::math::{GridPoint, GridVector};
+use all_is_cubes::math::{Cube, GridVector};
 use all_is_cubes::space::SpaceTransaction;
 use all_is_cubes::time::Tick;
 
@@ -34,11 +34,9 @@ impl vui::Layoutable for Crosshair {
 
 impl vui::Widget for Crosshair {
     fn controller(self: Arc<Self>, position: &vui::LayoutGrant) -> Box<dyn vui::WidgetController> {
-        assert!(position
-            .bounds
-            .contains_cube(position.bounds.lower_bounds()));
+        let position = position.shrink_to_cube().unwrap();
         Box::new(CrosshairController {
-            position: position.bounds.lower_bounds(),
+            position,
             todo: DirtyFlag::listening(false, &self.mouselook_mode),
             definition: self,
         })
@@ -49,7 +47,7 @@ impl vui::Widget for Crosshair {
 #[derive(Debug)]
 pub(crate) struct CrosshairController {
     definition: Arc<Crosshair>,
-    position: GridPoint,
+    position: Cube,
     todo: DirtyFlag,
 }
 

--- a/all-is-cubes-ui/src/vui/widgets/toolbar.rs
+++ b/all-is-cubes-ui/src/vui/widgets/toolbar.rs
@@ -15,7 +15,7 @@ use all_is_cubes::drawing::embedded_graphics::{
 };
 use all_is_cubes::inv::{Slot, TOOL_SELECTIONS};
 use all_is_cubes::listen::{DirtyFlag, Gate, Listen as _, ListenableSource, Listener};
-use all_is_cubes::math::{FaceMap, GridAab, GridCoordinate, GridPoint, GridVector, Gridgid};
+use all_is_cubes::math::{Cube, FaceMap, GridAab, GridCoordinate, GridPoint, GridVector, Gridgid};
 use all_is_cubes::space::{Space, SpacePhysics, SpaceTransaction};
 use all_is_cubes::time::Tick;
 use all_is_cubes::transaction::Merge as _;
@@ -119,7 +119,7 @@ impl Widget for Toolbar {
             character,
             character_listener_gate,
             // TODO: obey gravity when positioning within the grant
-            first_slot_position: GridPoint::new(
+            first_slot_position: Cube::new(
                 (bounds.lower_bounds().x + bounds.upper_bounds().x) / 2
                     - (self.slot_count as GridCoordinate) * Toolbar::TOOLBAR_STEP / 2
                     + 1,
@@ -142,11 +142,11 @@ struct ToolbarController {
     /// TODO: Generalize to noncharacters
     character: Option<URef<Character>>,
     character_listener_gate: Gate,
-    first_slot_position: GridPoint,
+    first_slot_position: Cube,
 }
 
 impl ToolbarController {
-    fn slot_position(&self, slot_index: usize) -> GridPoint {
+    fn slot_position(&self, slot_index: usize) -> Cube {
         self.first_slot_position + GridVector::unit_x() * 2 * slot_index as GridCoordinate
     }
 

--- a/all-is-cubes-ui/src/vui/widgets/voxels.rs
+++ b/all-is-cubes-ui/src/vui/widgets/voxels.rs
@@ -94,7 +94,9 @@ impl vui::Widget for Voxels {
                 cube,
                 Block::from_primitive(Primitive::Recur {
                     attributes: self.block_attributes.clone(),
-                    offset: block_to_voxels_transform.transform_cube(cube),
+                    offset: block_to_voxels_transform
+                        .transform_cube(cube)
+                        .lower_bounds(),
                     resolution: self.scale,
                     space: self.space.clone(),
                 }),
@@ -110,6 +112,7 @@ mod tests {
     use crate::vui::{instantiate_widget, Align};
     use all_is_cubes::block::Resolution::*;
     use all_is_cubes::cgmath::{Point3, Vector3};
+    use all_is_cubes::math::Cube;
     use all_is_cubes::universe::Universe;
 
     fn test_voxels_widget(
@@ -133,7 +136,7 @@ mod tests {
     #[test]
     fn voxels_in_too_small_grant_succeeds() {
         let v_space_bounds = GridAab::from_lower_upper([0, 0, 0], [7, 8, 9]);
-        let output_origin = GridPoint::new(100, 100, 100);
+        let output_origin = Cube::new(100, 100, 100);
         let _output = test_voxels_widget(
             v_space_bounds,
             vui::LayoutGrant::new(GridAab::single_cube(output_origin)),

--- a/all-is-cubes-wasm/src/gameapp.rs
+++ b/all-is-cubes-wasm/src/gameapp.rs
@@ -68,7 +68,7 @@ impl WebSession {
         fullscreen_cell: ListenableCell<Option<bool>>,
     ) -> Rc<Self> {
         let self_rc = Rc::new_cyclic(|weak_self| {
-            let new_self = Self {
+            Self {
                 gui_helpers,
                 static_dom,
                 viewport_cell,
@@ -97,9 +97,7 @@ impl WebSession {
                     last_raf_timestamp: 0.0, // TODO better initial value or special case
                     last_step_info: UniverseStepInfo::default(),
                 }),
-            };
-
-            new_self
+            }
         });
 
         self_rc.clone().init_dom();
@@ -312,7 +310,7 @@ impl WebSession {
     {
         if let Some(strong_self_ref) = weak_self_ref.upgrade() {
             match strong_self_ref.inner_cell.try_borrow_mut() {
-                Ok(mut inner) => body(&strong_self_ref, &mut *inner),
+                Ok(mut inner) => body(&strong_self_ref, &mut inner),
                 Err(BorrowMutError { .. }) => {
                     // We probably left the cell borrowed in a previous panic.
                     // Log, but don't panic again because it will only create log spam.

--- a/all-is-cubes/benches/chunk_bench.rs
+++ b/all-is-cubes/benches/chunk_bench.rs
@@ -2,9 +2,9 @@ use cgmath::{Basis3, Decomposed, One, Vector3};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use all_is_cubes::camera::{Camera, GraphicsOptions, Viewport};
-use all_is_cubes::cgmath::{Point3, Vector2};
+use all_is_cubes::cgmath::Vector2;
 use all_is_cubes::chunking::{reset_chunk_chart_cache, ChunkChart, ChunkPos, OctantMask};
-use all_is_cubes::math::GridAab;
+use all_is_cubes::math::{Cube, GridAab};
 
 fn chunk_chart_bench(c: &mut Criterion) {
     let mut group = c.benchmark_group("ChunkChart");
@@ -42,7 +42,7 @@ fn cull_bench(c: &mut Criterion) {
         b.iter(|| {
             let mut matched = 0;
             for p in chart
-                .chunks(ChunkPos(Point3::new(0, 0, 0)), OctantMask::ALL)
+                .chunks(ChunkPos(Cube::new(0, 0, 0)), OctantMask::ALL)
                 .rev()
             {
                 if chunked_bounds.contains_cube(p.0) {
@@ -57,10 +57,7 @@ fn cull_bench(c: &mut Criterion) {
     c.bench_function("frustum-bounds", |b| {
         b.iter(|| {
             let mut matched = 0;
-            for p in chart
-                .chunks(ChunkPos(Point3::new(0, 0, 0)), OctantMask::ALL)
-                .rev()
-            {
+            for p in chart.chunks(ChunkPos(Cube::ORIGIN), OctantMask::ALL).rev() {
                 if camera.aab_in_view(p.bounds().into()) && chunked_bounds.contains_cube(p.0) {
                     matched += 1;
                 }
@@ -73,10 +70,7 @@ fn cull_bench(c: &mut Criterion) {
     c.bench_function("bounds-frustum", |b| {
         b.iter(|| {
             let mut matched = 0;
-            for p in chart
-                .chunks(ChunkPos(Point3::new(0, 0, 0)), OctantMask::ALL)
-                .rev()
-            {
+            for p in chart.chunks(ChunkPos(Cube::ORIGIN), OctantMask::ALL).rev() {
                 if chunked_bounds.contains_cube(p.0) && camera.aab_in_view(p.bounds().into()) {
                     matched += 1;
                 }
@@ -90,7 +84,7 @@ fn cull_bench(c: &mut Criterion) {
         b.iter(|| {
             let mut matched = 0;
             for p in chart
-                .chunks(ChunkPos(Point3::new(0, 0, 0)), camera.view_direction_mask())
+                .chunks(ChunkPos(Cube::ORIGIN), camera.view_direction_mask())
                 .rev()
             {
                 if camera.aab_in_view(p.bounds().into()) && chunked_bounds.contains_cube(p.0) {
@@ -106,7 +100,7 @@ fn cull_bench(c: &mut Criterion) {
         b.iter(|| {
             let mut matched = 0;
             for p in chart
-                .chunks(ChunkPos(Point3::new(0, 0, 0)), camera.view_direction_mask())
+                .chunks(ChunkPos(Cube::ORIGIN), camera.view_direction_mask())
                 .rev()
             {
                 if chunked_bounds.contains_cube(p.0) && camera.aab_in_view(p.bounds().into()) {

--- a/all-is-cubes/src/block.rs
+++ b/all-is-cubes/src/block.rs
@@ -13,7 +13,7 @@ use cgmath::{EuclideanSpace as _, Point3};
 
 use crate::listen::{self, Listen, Listener};
 use crate::math::{
-    FreeCoordinate, GridAab, GridArray, GridCoordinate, GridPoint, GridRotation, Rgb, Rgba,
+    Cube, FreeCoordinate, GridAab, GridArray, GridCoordinate, GridPoint, GridRotation, Rgb, Rgba,
 };
 use crate::raycast::Ray;
 use crate::space::{SetCubeError, Space, SpaceChange};
@@ -751,10 +751,11 @@ pub const AIR: Block = Block(BlockPtr::Static(&Primitive::Air));
 // TODO: Replace this with the ability to ask a Raycaster to zoom in,
 // for more precision in edge cases
 #[inline]
-pub(crate) fn recursive_ray(ray: Ray, cube: GridPoint, resolution: Resolution) -> Ray {
+pub(crate) fn recursive_ray(ray: Ray, cube: Cube, resolution: Resolution) -> Ray {
     Ray {
         origin: Point3::from_vec(
-            (ray.origin - cube.map(FreeCoordinate::from)) * FreeCoordinate::from(resolution),
+            (ray.origin - cube.lower_bounds().map(FreeCoordinate::from))
+                * FreeCoordinate::from(resolution),
         ),
         direction: ray.direction,
     }
@@ -878,7 +879,7 @@ pub fn space_to_blocks(
     destination_space.fill(destination_bounds, move |cube| {
         Some(Block::from_primitive(Primitive::Recur {
             attributes: attributes.clone(),
-            offset: GridPoint::from_vec(cube.to_vec() * resolution_g),
+            offset: GridPoint::from_vec(cube.lower_bounds().to_vec() * resolution_g),
             resolution,
             space: space_ref.clone(),
         }))

--- a/all-is-cubes/src/block/builder.rs
+++ b/all-is-cubes/src/block/builder.rs
@@ -9,7 +9,7 @@ use crate::block::{
     Modifier, Primitive, Resolution, RotationPlacementRule, AIR,
 };
 use crate::drawing::VoxelBrush;
-use crate::math::{GridPoint, Rgb, Rgba};
+use crate::math::{Cube, GridPoint, Rgb, Rgba};
 use crate::space::{SetCubeError, Space};
 use crate::universe::{Name, URef, Universe};
 
@@ -160,7 +160,7 @@ impl<C> BlockBuilder<C> {
         mut function: F,
     ) -> Result<BlockBuilder<BlockBuilderVoxels>, SetCubeError>
     where
-        F: FnMut(GridPoint) -> B,
+        F: FnMut(Cube) -> B,
         B: std::borrow::Borrow<Block>,
     {
         let mut space = Space::for_block(resolution).build();

--- a/all-is-cubes/src/block/evaluated.rs
+++ b/all-is-cubes/src/block/evaluated.rs
@@ -9,8 +9,7 @@ use crate::block::{
     Resolution::{self, R1},
 };
 use crate::content::palette;
-use crate::math::Face6;
-use crate::math::{FaceMap, GridAab, GridArray, GridPoint, OpacityCategory, Rgb, Rgba};
+use crate::math::{Cube, Face6, FaceMap, GridAab, GridArray, OpacityCategory, Rgb, Rgba};
 use crate::raytracer;
 use crate::universe::RefError;
 
@@ -172,7 +171,7 @@ impl EvaluatedBlock {
 
                 for v in rotated_voxel_range.y_range() {
                     for u in rotated_voxel_range.x_range() {
-                        let cube: GridPoint = transform.transform_cube(GridPoint::new(
+                        let cube: Cube = transform.transform_cube(Cube::new(
                             u,
                             v,
                             rotated_voxel_range.z_range().start,
@@ -492,9 +491,9 @@ impl Evoxels {
     ///
     /// TODO: Should we inherently return AIR instead of None?
     #[inline]
-    pub fn get(&self, position: GridPoint) -> Option<Evoxel> {
+    pub fn get(&self, position: Cube) -> Option<Evoxel> {
         match (self, position) {
-            (&Evoxels::One(voxel), GridPoint { x: 0, y: 0, z: 0 }) => Some(voxel),
+            (&Evoxels::One(voxel), Cube::ORIGIN) => Some(voxel),
             (Evoxels::One(_), _) => None,
             (Evoxels::Many(_, ref voxels), position) => voxels.get(position).copied(),
         }
@@ -518,14 +517,14 @@ impl Evoxels {
     }
 }
 
-impl std::ops::Index<GridPoint> for Evoxels {
+impl std::ops::Index<Cube> for Evoxels {
     type Output = Evoxel;
 
     #[inline]
     #[track_caller]
-    fn index(&self, position: GridPoint) -> &Self::Output {
+    fn index(&self, position: Cube) -> &Self::Output {
         match (self, position) {
-            (Evoxels::One(voxel), GridPoint { x: 0, y: 0, z: 0 }) => voxel,
+            (Evoxels::One(voxel), Cube::ORIGIN) => voxel,
             (Evoxels::One(_), _) => panic!("out of bounds of Evoxels::One"),
             (Evoxels::Many(_, voxels), position) => &voxels[position],
         }

--- a/all-is-cubes/src/block/modifier.rs
+++ b/all-is-cubes/src/block/modifier.rs
@@ -191,7 +191,7 @@ mod tests {
     use super::*;
     use crate::block::{BlockCollision, EvaluatedBlock, Evoxel, Primitive, Resolution::R2};
     use crate::content::make_some_voxel_blocks;
-    use crate::math::{Face6, FaceMap, GridAab, GridPoint, OpacityCategory, Rgba};
+    use crate::math::{Cube, Face6, FaceMap, GridAab, OpacityCategory, Rgba};
     use crate::universe::Universe;
     use pretty_assertions::assert_eq;
 
@@ -201,7 +201,7 @@ mod tests {
         let block_bounds = GridAab::for_block(resolution);
         let rotation = GridRotation::RYXZ;
         let mut universe = Universe::new();
-        let color_fn = |cube: GridPoint| {
+        let color_fn = |cube: Cube| {
             Rgba::new(
                 cube.x as f32,
                 cube.y as f32,
@@ -209,7 +209,7 @@ mod tests {
                 if cube.y == 0 { 1.0 } else { 0.0 },
             )
         };
-        let rotated_color_fn = |cube: GridPoint| {
+        let rotated_color_fn = |cube: Cube| {
             color_fn(
                 rotation
                     .to_positive_octant_transform(resolution.into())

--- a/all-is-cubes/src/block/modifier/composite.rs
+++ b/all-is-cubes/src/block/modifier/composite.rs
@@ -5,7 +5,7 @@ use ordered_float::NotNan;
 use crate::block::{
     self, Block, BlockCollision, Evoxel, Evoxels, MinEval, Modifier, Resolution::R1, AIR,
 };
-use crate::math::{GridAab, GridArray, GridCoordinate, GridRotation, Rgb};
+use crate::math::{Cube, GridAab, GridArray, GridCoordinate, GridRotation, Rgb};
 use crate::universe;
 
 /// Data for [`Modifier::Composite`], describing how to combine the voxels of another
@@ -181,10 +181,15 @@ impl Composite {
                 // TODO: use narrower array bounds (union of both inputs' bounds)
                 voxels: Evoxels::Many(
                     effective_resolution,
-                    GridArray::from_fn(GridAab::for_block(effective_resolution), |p| {
+                    GridArray::from_fn(GridAab::for_block(effective_resolution), |cube| {
+                        let p = cube.lower_bounds();
                         operator.blend_evoxel(
-                            src_voxels.get(p / src_scale).unwrap_or(Evoxel::AIR),
-                            dst_voxels.get(p / dst_scale).unwrap_or(Evoxel::AIR),
+                            src_voxels
+                                .get(Cube::from(p / src_scale))
+                                .unwrap_or(Evoxel::AIR),
+                            dst_voxels
+                                .get(Cube::from(p / dst_scale))
+                                .unwrap_or(Evoxel::AIR),
                         )
                     }),
                 ),

--- a/all-is-cubes/src/block/modifier/zoom.rs
+++ b/all-is-cubes/src/block/modifier/zoom.rs
@@ -4,7 +4,7 @@ use crate::block::{
     self, Evoxel, Evoxels, MinEval, Modifier,
     Resolution::{self, R1},
 };
-use crate::math::{GridAab, GridArray, GridCoordinate, GridPoint};
+use crate::math::{Cube, GridAab, GridArray, GridCoordinate, GridPoint};
 use crate::universe;
 
 /// Data for [`Modifier::Zoom`], describing a portion of the original block that is scaled
@@ -36,7 +36,7 @@ impl Zoom {
     /// greater than `scale - 1`.
     #[track_caller]
     pub fn new(scale: Resolution, offset: GridPoint) -> Self {
-        if !GridAab::for_block(scale).contains_cube(offset) {
+        if !GridAab::for_block(scale).contains_cube(Cube::from(offset)) {
             panic!("Zoom offset {offset:?} out of bounds for {scale}");
         }
 

--- a/all-is-cubes/src/content.rs
+++ b/all-is-cubes/src/content.rs
@@ -186,10 +186,10 @@ pub fn axes(space: &mut Space) -> Result<(), SetCubeError> {
             palette::UNIFORM_LUMINANCE_BLUE,
         ][axis];
         let direction = face.normal_vector::<GridCoordinate>()[axis];
-        let raycaster = Raycaster::new((0.5, 0.5, 0.5), face.normal_vector::<FreeCoordinate>())
+        let raycaster = Raycaster::new([0.5, 0.5, 0.5], face.normal_vector::<FreeCoordinate>())
             .within(space.bounds());
         for step in raycaster {
-            let i = step.cube_ahead()[axis] * direction; // always positive
+            let i = step.cube_ahead().lower_bounds()[axis] * direction; // always positive
             let (color, display_name): (Rgb, Cow<'static, str>) = if i.rem_euclid(2) == 0 {
                 (axis_color, i.rem_euclid(10).to_string().into())
             } else {

--- a/all-is-cubes/src/content/load_image.rs
+++ b/all-is-cubes/src/content/load_image.rs
@@ -212,7 +212,7 @@ mod tests {
             space.bounds(),
             GridAab::from_lower_upper([0, 0, 0], [2, 2, 1])
         );
-        assert_eq!(space[(1, 0, 0)], Block::from(Rgb::new(1., 0., 0.)));
+        assert_eq!(space[[1, 0, 0]], Block::from(Rgb::new(1., 0., 0.)));
     }
 
     #[test]
@@ -224,10 +224,10 @@ mod tests {
             GridAab::from_lower_upper([0, 0, 0], [2, 1, 2])
         );
         // X is flipped
-        assert_eq!(space[(1, 0, 0)], Block::from(Rgb::new(0., 0., 0.)));
-        assert_eq!(space[(0, 0, 0)], Block::from(Rgb::new(1., 0., 0.)));
+        assert_eq!(space[[1, 0, 0]], Block::from(Rgb::new(0., 0., 0.)));
+        assert_eq!(space[[0, 0, 0]], Block::from(Rgb::new(1., 0., 0.)));
         // and Y becomes Z
-        assert_eq!(space[(0, 0, 1)], Block::from(Rgb::new(1., 1., 0.)));
+        assert_eq!(space[[0, 0, 1]], Block::from(Rgb::new(1., 1., 0.)));
     }
 
     #[test]
@@ -253,6 +253,6 @@ mod tests {
             space.bounds(),
             GridAab::from_lower_upper([10, 0, 0], [12, 2, 1])
         );
-        assert_eq!(space[(11, 0, 0)], Block::from(Rgb::new(1., 0., 0.)));
+        assert_eq!(space[[11, 0, 0]], Block::from(Rgb::new(1., 0., 0.)));
     }
 }

--- a/all-is-cubes/src/inv/icons.rs
+++ b/all-is-cubes/src/inv/icons.rs
@@ -10,10 +10,7 @@ use crate::block::{Block, Resolution::*, AIR, AIR_EVALUATED};
 use crate::content::load_image::{default_srgb, include_image, space_from_image};
 use crate::drawing::VoxelBrush;
 use crate::linking::{BlockModule, BlockProvider};
-use crate::math::{
-    cube_to_midpoint, Face6, FreeCoordinate, GridCoordinate, GridRotation, GridVector, Gridgid,
-    Rgba,
-};
+use crate::math::{Face6, FreeCoordinate, GridCoordinate, GridRotation, GridVector, Gridgid, Rgba};
 use crate::space::Space;
 use crate::universe::Universe;
 
@@ -101,11 +98,11 @@ impl Icons {
                     let background_block_1: Block = Rgba::new(1.0, 0.05, 0.0, 1.0).into(); // TODO: Use palette colors
                     let background_block_2: Block = Rgba::new(0.8, 0.05, 0.0, 1.0).into(); // TODO: Use palette colors
                     let background_brush = VoxelBrush::new([
-                        ((0, 0, 1), &background_block_1),
-                        ((1, 0, 0), &background_block_2),
-                        ((-1, 0, 0), &background_block_2),
-                        ((0, 1, 0), &background_block_2),
-                        ((0, -1, 0), &background_block_2),
+                        ([0, 0, 1], &background_block_1),
+                        ([1, 0, 0], &background_block_2),
+                        ([-1, 0, 0], &background_block_2),
+                        ([0, 1, 0], &background_block_2),
+                        ([0, -1, 0], &background_block_2),
                     ]);
                     let line_brush = VoxelBrush::single(Block::from(Rgba::BLACK))
                         .translate(GridVector::new(0, 0, 2));
@@ -238,11 +235,11 @@ impl Icons {
                         } else {
                             "Jetpack (off)"
                         })
-                        .voxels_fn(universe, resolution, |p| {
+                        .voxels_fn(universe, resolution, |cube| {
                             let (shape_radius, block) =
-                                shape[((GridCoordinate::from(resolution) - 1) - p.y) as usize];
+                                shape[((GridCoordinate::from(resolution) - 1) - cube.y) as usize];
                             let centered_p =
-                                cube_to_midpoint(p).map(|c| c - f64::from(resolution) / 2.0);
+                                cube.midpoint().map(|c| c - f64::from(resolution) / 2.0);
                             let r4 = centered_p
                                 .to_vec()
                                 .mul_element_wise(Vector3::new(1., 0., 1.))

--- a/all-is-cubes/src/math.rs
+++ b/all-is-cubes/src/math.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-use cgmath::{EuclideanSpace as _, Point3, Vector3};
+use cgmath::{Point3, Vector3};
 use num_traits::identities::Zero;
 pub use ordered_float::{FloatIsNan, NotNan};
 
@@ -15,6 +15,8 @@ mod color;
 pub use color::*;
 mod coord;
 pub use coord::*;
+mod cube;
+pub use cube::Cube;
 mod face;
 pub use face::*;
 mod grid_aab;
@@ -92,15 +94,6 @@ macro_rules! notnan {
 pub(crate) fn smoothstep(x: f64) -> f64 {
     let x = x.clamp(0.0, 1.0);
     3. * x.powi(2) - 2. * x.powi(3)
-}
-
-#[inline]
-pub(crate) fn point_checked_add(p: GridPoint, v: GridVector) -> Option<GridPoint> {
-    Some(GridPoint {
-        x: p.x.checked_add(v.x)?,
-        y: p.y.checked_add(v.y)?,
-        z: p.z.checked_add(v.z)?,
-    })
 }
 
 /// Sort exactly two items; swap them if `a > b`.

--- a/all-is-cubes/src/math/aab.rs
+++ b/all-is-cubes/src/math/aab.rs
@@ -4,9 +4,7 @@ use std::iter::FusedIterator;
 
 use cgmath::{EuclideanSpace as _, Point3, Vector3, Zero as _};
 
-use crate::math::{
-    Face6, FreeCoordinate, Geometry, GridAab, GridCoordinate, GridPoint, LineVertex,
-};
+use crate::math::{Face6, FreeCoordinate, Geometry, GridAab, GridCoordinate, LineVertex};
 
 /// Axis-Aligned Box data type.
 ///
@@ -97,23 +95,6 @@ impl Aab {
         } else {
             None
         }
-    }
-
-    /// Returns the AAB of a given cube in the interpretation used by [`GridAab`] and
-    /// [`Space`](crate::space::Space); that is, a unit cube extending in the positive
-    /// directions from the given point.
-    ///
-    /// ```
-    /// use all_is_cubes::math::{Aab, GridPoint};
-    ///
-    /// assert_eq!(
-    ///     Aab::from_cube(GridPoint::new(10, 20, -30)),
-    ///     Aab::new(10.0, 11.0, 20.0, 21.0, -30.0, -29.0)
-    /// );
-    /// ```
-    pub fn from_cube(cube: GridPoint) -> Self {
-        let lower = cube.cast::<FreeCoordinate>().unwrap();
-        Self::from_lower_upper(lower, lower + Vector3::new(1.0, 1.0, 1.0))
     }
 
     /// The most negative corner of the box, as a [`Point3`].
@@ -386,6 +367,8 @@ impl Geometry for Aab {
 
 #[cfg(test)]
 mod tests {
+    use crate::math::Cube;
+
     use super::*;
 
     #[test]
@@ -478,7 +461,7 @@ mod tests {
 
     #[test]
     fn wireframe_smoke_test() {
-        let aab = Aab::from_cube(Point3::new(1, 2, 3));
+        let aab: Aab = Cube::new(1, 2, 3).aab();
         let mut wireframe: Vec<LineVertex> = Vec::new();
         aab.wireframe_points(&mut wireframe);
         for LineVertex { position, color } in wireframe {
@@ -495,7 +478,7 @@ mod tests {
         for direction in (-1..=1)
             .zip(-1..=1)
             .zip(-1..=1)
-            .map(|((x, y), z)| Vector3::new(x, y, z).cast::<FreeCoordinate>().unwrap())
+            .map(|((x, y), z)| Vector3::new(x, y, z).map(FreeCoordinate::from))
         {
             let leading_corner = aab.leading_corner(direction);
 
@@ -512,10 +495,11 @@ mod tests {
     #[test]
     fn corner_points() {
         // use all_is_cubes::cgmath::Point3;
-        // use all_is_cubes::math::{Aab, GridPoint};
+        // use all_is_cubes::math::{Aab, Cube};
 
         assert_eq!(
-            Aab::from_cube(GridPoint::new(10, 20, 30))
+            Cube::new(10, 20, 30)
+                .aab()
                 .corner_points()
                 .collect::<Vec<_>>(),
             vec![

--- a/all-is-cubes/src/math/coord.rs
+++ b/all-is-cubes/src/math/coord.rs
@@ -18,91 +18,10 @@ pub type GridVector = Vector3<GridCoordinate>;
 /// `From<GridCoordinate> for FreeCoordinate` exists, which is often convenient.
 pub type FreeCoordinate = f64;
 
-/// Convert a `GridPoint` used to identify a cube to the midpoint of that cube.
-/// That is, convert the number type and add 0.5.
-#[inline(always)] // trivial arithmetic that almost certainly should be inlined
-pub fn cube_to_midpoint(cube: GridPoint) -> Point3<FreeCoordinate> {
-    cube.map(|component| FreeCoordinate::from(component) + 0.5)
-}
-
-/// Convert a point in space to the unit cube that encloses it.
-///
-/// Such cubes are defined to be half-open intervals on each axis; that is,
-/// an integer coordinate is counted as part of the cube extending positively
-/// from that coordinate.
-///
-/// If the point coordinates are outside of the numeric range of [`GridCoordinate`],
-/// returns [`None`].
-///
-/// ```
-/// use all_is_cubes::cgmath::Point3;
-/// use all_is_cubes::math::point_to_enclosing_cube;
-///
-/// assert_eq!(point_to_enclosing_cube(Point3::new(1.0, 1.5, -2.5)), Some(Point3::new(1, 1, -3)));
-/// ```
-#[inline(always)] // trivial arithmetic that almost certainly should be inlined
-pub fn point_to_enclosing_cube(point: Point3<FreeCoordinate>) -> Option<GridPoint> {
-    const RANGE: std::ops::Range<FreeCoordinate> =
-        (GridCoordinate::MIN as FreeCoordinate)..(GridCoordinate::MAX as FreeCoordinate + 1.0);
-
-    if RANGE.contains(&point.x) && RANGE.contains(&point.y) && RANGE.contains(&point.z) {
-        Some(point.map(|component| component.floor() as GridCoordinate))
-    } else {
-        None
-    }
-}
-
 /// Compute the squared magnitude of a [`GridVector`].
 ///
 /// [`cgmath::InnerSpace::magnitude2`] would do the same but only for floats.
 #[inline(always)] // trivial arithmetic that almost certainly should be inlined
 pub(crate) fn int_magnitude_squared(v: GridVector) -> GridCoordinate {
     v.x * v.x + v.y * v.y + v.z * v.z
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn point_to_enclosing_cube_inf() {
-        assert_eq!(
-            point_to_enclosing_cube(Point3::new(FreeCoordinate::INFINITY, 0., 0.)),
-            None
-        );
-        assert_eq!(
-            point_to_enclosing_cube(Point3::new(-FreeCoordinate::INFINITY, 0., 0.)),
-            None
-        );
-    }
-
-    #[test]
-    fn point_to_enclosing_cube_nan() {
-        assert_eq!(
-            point_to_enclosing_cube(Point3::new(0., 0., FreeCoordinate::NAN)),
-            None
-        );
-    }
-
-    #[test]
-    fn point_to_enclosing_cube_in_and_out_of_range() {
-        let fmax = FreeCoordinate::from(GridCoordinate::MAX);
-        let fmin = FreeCoordinate::from(GridCoordinate::MIN);
-        assert_eq!(
-            point_to_enclosing_cube(Point3::new(0., 0., fmin - 0.001,)),
-            None
-        );
-        assert_eq!(
-            point_to_enclosing_cube(Point3::new(0., 0., fmin + 0.001,)),
-            Some(Point3::new(0, 0, GridCoordinate::MIN))
-        );
-        assert_eq!(
-            point_to_enclosing_cube(Point3::new(0., 0., fmax + 0.999,)),
-            Some(Point3::new(0, 0, GridCoordinate::MAX))
-        );
-        assert_eq!(
-            point_to_enclosing_cube(Point3::new(0., 0., fmax + 1.001,)),
-            None
-        );
-    }
 }

--- a/all-is-cubes/src/math/cube.rs
+++ b/all-is-cubes/src/math/cube.rs
@@ -1,0 +1,302 @@
+use core::fmt;
+
+use cgmath::{Point3, Vector3};
+
+use crate::math::{Aab, FreeCoordinate, GridAab, GridCoordinate, GridPoint, GridVector};
+use crate::util::ConciseDebug;
+
+/// “A cube”, in this documentation, is a unit cube whose corners' coordinates are integers.
+/// This type identifies such a cube by the coordinates of its most negative corner.
+///
+/// The valid coordinate range is that of [`GridCoordinate`].
+/// Note, however, that in most applications, cubes with lower corner coordinates equal to
+/// [`GridCoordinate::MAX`] will not be valid, because their other corners are out of
+/// range. The [`Cube`] type does not enforce this, because it would be unergonomic to
+/// require fallible conversions there. Instead, the conversion from [`Cube`] to its
+/// bounding [`GridAab`] may panic. Generally, this should be avoided by checking
+/// the cube with [`GridAab::contains_cube()`] on some existing [`GridAab`].
+///
+/// Considered in continuous space (real, or floating-point, coordinates), the ranges of
+/// coordinates a cube contains are half-open intervals: lower inclusive and upper exclusive.
+///
+/// # Representation
+///
+/// This struct is guaranteed to be three `i32` without padding, and so may be reinterpreted
+/// as any type of identical layout such as `[i32; 3]`.
+///
+/// # Why have a dedicated type for this?
+///
+/// * Primarily, to avoid confusion between points (zero size) and cubes (nonzero size)
+///   that causes off-by-one errors when rotating objects.
+/// * To provide convenient methods for operations on cubes that aren't natural operations
+///   on points.
+/// * To reduce our dependence on external math libraries as part of our API.
+#[derive(Clone, Copy, Eq, Hash, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[allow(missing_docs, clippy::exhaustive_structs)]
+#[repr(C)]
+pub struct Cube {
+    pub x: i32,
+    pub y: i32,
+    pub z: i32,
+}
+
+impl Cube {
+    /// Equal to `Cube::new(0, 0, 0)`.
+    ///
+    /// Note that this is not a box _centered_ on the coordinate origin.
+    pub const ORIGIN: Self = Self::new(0, 0, 0);
+
+    /// Construct `Cube { x, y, z }` from the given coordinates.
+    #[inline]
+    pub const fn new(x: GridCoordinate, y: GridCoordinate, z: GridCoordinate) -> Self {
+        Self { x, y, z }
+    }
+
+    /// Convert a point in space to the unit cube that encloses it.
+    ///
+    /// Such cubes are defined to be half-open intervals on each axis; that is,
+    /// an integer coordinate is counted as part of the cube extending positively
+    /// from that coordinate.
+    ///
+    /// If the point coordinates are outside of the numeric range of [`GridCoordinate`],
+    /// returns [`None`].
+    ///
+    /// ```
+    /// use all_is_cubes::cgmath::Point3;
+    /// use all_is_cubes::math::Cube;
+    ///
+    /// assert_eq!(Cube::containing(Point3::new(1.0, 1.5, -2.5)), Some(Cube::new(1, 1, -3)));
+    /// ```
+    #[inline]
+    pub fn containing(point: Point3<FreeCoordinate>) -> Option<Self> {
+        const RANGE: std::ops::Range<FreeCoordinate> =
+            (GridCoordinate::MIN as FreeCoordinate)..(GridCoordinate::MAX as FreeCoordinate + 1.0);
+
+        if RANGE.contains(&point.x) && RANGE.contains(&point.y) && RANGE.contains(&point.z) {
+            Some(Self::from(
+                point.map(|component| component.floor() as GridCoordinate),
+            ))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the corner of this cube with the most negative coordinates.
+    #[inline] // trivial arithmetic
+    pub fn lower_bounds(self) -> GridPoint {
+        self.into()
+    }
+
+    /// Returns the corner of this cube with the most positive coordinates.
+    ///
+    /// Panics if `self` has any coordinates equal to [`GridCoordinate::MAX`].
+    /// Generally, that should be avoided by checking the cube with
+    /// [`GridAab::contains_cube()`] on some existing [`GridAab`] before calling this
+    /// method.
+    #[inline]
+    #[track_caller]
+    pub fn upper_bounds(self) -> GridPoint {
+        self.checked_add(GridVector::new(1, 1, 1))
+            .expect("Cube::upper_bounds() overflowed")
+            .lower_bounds()
+    }
+
+    /// Returns the midpoint of this cube.
+    #[inline] // trivial arithmetic
+    pub fn midpoint(self) -> Point3<FreeCoordinate> {
+        let Self { x, y, z } = self;
+        Point3 {
+            x: FreeCoordinate::from(x) + 0.5,
+            y: FreeCoordinate::from(y) + 0.5,
+            z: FreeCoordinate::from(z) + 0.5,
+        }
+    }
+
+    /// Constructs a [`GridAab`] with a volume of 1, containing this cube.
+    ///
+    /// Panics if `self` has any coordinates equal to [`GridCoordinate::MAX`].
+    /// Generally, that should be avoided by checking the cube with
+    /// [`GridAab::contains_cube()`] on some existing [`GridAab`] before calling this
+    /// method.
+    #[inline]
+    pub fn grid_aab(self) -> GridAab {
+        GridAab::from_lower_size(self.lower_bounds(), [1, 1, 1])
+    }
+
+    /// Returns the bounding box in floating-point coordinates containing this cube.
+    ///
+    /// ```
+    /// use all_is_cubes::math::{Aab, Cube};
+    ///
+    /// assert_eq!(
+    ///     Cube::new(10, 20, -30).aab(),
+    ///     Aab::new(10.0, 11.0, 20.0, 21.0, -30.0, -29.0)
+    /// );
+    /// ```
+    #[inline]
+    pub fn aab(self) -> Aab {
+        // Note: this does not use `.upper_bounds()` so that it is non-panicking.
+        let lower = GridPoint::from(self).map(FreeCoordinate::from);
+        Aab::from_lower_upper(lower, lower + Vector3::new(1.0, 1.0, 1.0))
+    }
+
+    /// Componentwise [`GridCoordinate::checked_add()`].
+    #[inline]
+    #[must_use]
+    pub(crate) fn checked_add(self, v: GridVector) -> Option<Self> {
+        Some(Self {
+            x: self.x.checked_add(v.x)?,
+            y: self.y.checked_add(v.y)?,
+            z: self.z.checked_add(v.z)?,
+        })
+    }
+
+    /// Apply a function to each coordinate independently.
+    ///
+    /// If a different return type is desired, use `.lower_bounds().map(f)` instead.
+    #[allow(clippy::return_self_not_must_use)]
+    pub fn map(self, mut f: impl FnMut(GridCoordinate) -> GridCoordinate) -> Self {
+        Self {
+            x: f(self.x),
+            y: f(self.y),
+            z: f(self.z),
+        }
+    }
+}
+
+impl fmt::Debug for Cube {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { x, y, z } = self;
+        write!(f, "({x:+.3?}, {y:+.3?}, {z:+.3?})")
+    }
+}
+impl crate::util::CustomFormat<ConciseDebug> for Cube {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>, _: ConciseDebug) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+mod arithmetic {
+    use super::*;
+    use std::ops;
+
+    impl ops::Add<GridVector> for Cube {
+        type Output = Self;
+        fn add(self, rhs: GridVector) -> Self::Output {
+            Self::from(self.lower_bounds() + rhs)
+        }
+    }
+    impl ops::AddAssign<GridVector> for Cube {
+        fn add_assign(&mut self, rhs: GridVector) {
+            *self = Self::from(self.lower_bounds() + rhs)
+        }
+    }
+
+    impl ops::Sub<GridVector> for Cube {
+        type Output = Self;
+        fn sub(self, rhs: GridVector) -> Self::Output {
+            Self::from(self.lower_bounds() - rhs)
+        }
+    }
+    impl ops::SubAssign<GridVector> for Cube {
+        fn sub_assign(&mut self, rhs: GridVector) {
+            *self = Self::from(self.lower_bounds() - rhs)
+        }
+    }
+
+    impl ops::Sub<Cube> for Cube {
+        type Output = GridVector;
+        fn sub(self, rhs: Cube) -> Self::Output {
+            self.lower_bounds() - rhs.lower_bounds()
+        }
+    }
+}
+
+mod conversion {
+    use super::*;
+
+    impl AsRef<[GridCoordinate; 3]> for Cube {
+        fn as_ref(&self) -> &[GridCoordinate; 3] {
+            bytemuck::cast_ref(self)
+        }
+    }
+    impl AsMut<[GridCoordinate; 3]> for Cube {
+        fn as_mut(&mut self) -> &mut [GridCoordinate; 3] {
+            bytemuck::cast_mut(self)
+        }
+    }
+    impl std::borrow::Borrow<[GridCoordinate; 3]> for Cube {
+        fn borrow(&self) -> &[GridCoordinate; 3] {
+            bytemuck::cast_ref(self)
+        }
+    }
+    impl std::borrow::BorrowMut<[GridCoordinate; 3]> for Cube {
+        fn borrow_mut(&mut self) -> &mut [GridCoordinate; 3] {
+            bytemuck::cast_mut(self)
+        }
+    }
+
+    impl From<Cube> for [GridCoordinate; 3] {
+        fn from(Cube { x, y, z }: Cube) -> [GridCoordinate; 3] {
+            [x, y, z]
+        }
+    }
+    impl From<Cube> for GridPoint {
+        fn from(Cube { x, y, z }: Cube) -> GridPoint {
+            GridPoint { x, y, z }
+        }
+    }
+
+    impl From<[GridCoordinate; 3]> for Cube {
+        fn from([x, y, z]: [GridCoordinate; 3]) -> Self {
+            Self { x, y, z }
+        }
+    }
+    impl From<GridPoint> for Cube {
+        fn from(GridPoint { x, y, z }: GridPoint) -> Self {
+            Self { x, y, z }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn containing_inf() {
+        assert_eq!(
+            Cube::containing(Point3::new(FreeCoordinate::INFINITY, 0., 0.)),
+            None
+        );
+        assert_eq!(
+            Cube::containing(Point3::new(-FreeCoordinate::INFINITY, 0., 0.)),
+            None
+        );
+    }
+
+    #[test]
+    fn containing_nan() {
+        assert_eq!(
+            Cube::containing(Point3::new(0., 0., FreeCoordinate::NAN)),
+            None
+        );
+    }
+
+    #[test]
+    fn containing_in_and_out_of_range() {
+        let fmax = FreeCoordinate::from(GridCoordinate::MAX);
+        let fmin = FreeCoordinate::from(GridCoordinate::MIN);
+        assert_eq!(Cube::containing(Point3::new(0., 0., fmin - 0.001)), None);
+        assert_eq!(
+            Cube::containing(Point3::new(0., 0., fmin + 0.001,)),
+            Some(Cube::new(0, 0, GridCoordinate::MIN))
+        );
+        assert_eq!(
+            Cube::containing(Point3::new(0., 0., fmax + 0.999,)),
+            Some(Cube::new(0, 0, GridCoordinate::MAX))
+        );
+        assert_eq!(Cube::containing(Point3::new(0., 0., fmax + 1.001)), None);
+    }
+}

--- a/all-is-cubes/src/math/matrix.rs
+++ b/all-is-cubes/src/math/matrix.rs
@@ -10,8 +10,8 @@ use cgmath::{
 pub use ordered_float::{FloatIsNan, NotNan};
 
 use crate::math::{
-    Face6, Face7, FreeCoordinate, GridCoordinate, GridPoint, GridRotation, GridVector, Gridgid,
-    Point3,
+    Cube, Face6, Face7, FreeCoordinate, GridCoordinate, GridPoint, GridRotation, GridVector,
+    Gridgid, Point3,
 };
 
 /// A 4×3 affine transformation matrix in [`GridCoordinate`]s, rather than floats as
@@ -150,25 +150,27 @@ impl GridMatrix {
     /// that cube.
     ///
     /// ```
-    /// use all_is_cubes::math::{Face7::*, GridMatrix, GridPoint};
+    /// use all_is_cubes::math::{Cube, Face7::*, GridMatrix, GridPoint};
     /// use cgmath::Transform; // for transform_point
     ///
     /// // Translation without rotation has the usual definition.
     /// let matrix = GridMatrix::from_translation([10, 0, 0]);
-    /// assert_eq!(matrix.transform_cube(GridPoint::new(1, 1, 1)), GridPoint::new(11, 1, 1));
+    /// assert_eq!(matrix.transform_cube(Cube::new(1, 1, 1)), Cube::new(11, 1, 1));
     ///
     /// // With a rotation or reflection, the results are different.
     /// // TODO: Come up with a better example and explanation.
     /// let reflected = GridMatrix::from_origin([10, 0, 0], NX, PY, PZ);
     /// assert_eq!(reflected.transform_point(GridPoint::new(1, 5, 5)), GridPoint::new(9, 5, 5));
-    /// assert_eq!(reflected.transform_cube(GridPoint::new(1, 5, 5)), GridPoint::new(8, 5, 5));
+    /// assert_eq!(reflected.transform_cube(Cube::new(1, 5, 5)), Cube::new(8, 5, 5));
     /// ```
     ///
     /// [`GridAab::single_cube`]: crate::math::GridAab::single_cube
     #[inline]
-    pub fn transform_cube(&self, cube: GridPoint) -> GridPoint {
-        self.transform_point(cube + Vector3::new(1, 1, 1))
-            .zip(self.transform_point(cube), |a, b| a.min(b))
+    pub fn transform_cube(&self, cube: Cube) -> Cube {
+        Cube::from(
+            self.transform_point(cube.lower_bounds())
+                .zip(self.transform_point(cube.upper_bounds()), |a, b| a.min(b)),
+        )
     }
 
     /// Decomposes a matrix into its rotation and translation components, stored in a

--- a/all-is-cubes/src/math/rotation.rs
+++ b/all-is-cubes/src/math/rotation.rs
@@ -302,12 +302,13 @@ impl GridRotation {
     /// *not* [`GridMatrix::transform_point`](cgmath::Transform::transform_point)
     /// (due to the lower-corner format of cube coordinates).
     /// ```
-    /// # use all_is_cubes::math::{GridAab, GridPoint, GridRotation};
+    /// use all_is_cubes::math::{GridAab, Cube, GridRotation};
+    ///
     /// let rotation = GridRotation::CLOCKWISE.to_positive_octant_transform(4);
-    /// assert_eq!(rotation.transform_cube(GridPoint::new(0, 0, 0)), GridPoint::new(3, 0, 0));
-    /// assert_eq!(rotation.transform_cube(GridPoint::new(3, 0, 0)), GridPoint::new(3, 0, 3));
-    /// assert_eq!(rotation.transform_cube(GridPoint::new(3, 0, 3)), GridPoint::new(0, 0, 3));
-    /// assert_eq!(rotation.transform_cube(GridPoint::new(0, 0, 3)), GridPoint::new(0, 0, 0));
+    /// assert_eq!(rotation.transform_cube(Cube::new(0, 0, 0)), Cube::new(3, 0, 0));
+    /// assert_eq!(rotation.transform_cube(Cube::new(3, 0, 0)), Cube::new(3, 0, 3));
+    /// assert_eq!(rotation.transform_cube(Cube::new(3, 0, 3)), Cube::new(0, 0, 3));
+    /// assert_eq!(rotation.transform_cube(Cube::new(0, 0, 3)), Cube::new(0, 0, 0));
     /// ```
     //
     // TODO: add tests
@@ -491,7 +492,7 @@ impl Mul<Self> for GridRotation {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cgmath::Transform as _;
+    use cgmath::{EuclideanSpace as _, Transform as _};
     use std::collections::HashSet;
     use Face6::*;
 

--- a/all-is-cubes/src/physics.rs
+++ b/all-is-cubes/src/physics.rs
@@ -15,7 +15,7 @@ mod tests {
     use super::*;
     use crate::block::{Resolution, AIR};
     use crate::content::{make_slab, make_some_blocks};
-    use crate::math::{Aab, CubeFace, Face7, Geometry, GridAab, GridPoint};
+    use crate::math::{Aab, Cube, CubeFace, Face7, Geometry, GridAab};
     use crate::space::{Space, SpacePhysics};
     use crate::time::Tick;
     use crate::universe::Universe;
@@ -31,7 +31,7 @@ mod tests {
         Body {
             flying: false,
             noclip: false,
-            ..Body::new_minimal((0., 2., 0.), Aab::new(-0.5, 0.5, -0.5, 0.5, -0.5, 0.5))
+            ..Body::new_minimal([0., 2., 0.], Aab::new(-0.5, 0.5, -0.5, 0.5, -0.5, 0.5))
         }
     }
 
@@ -81,7 +81,7 @@ mod tests {
     fn falling_collision() {
         let [block] = make_some_blocks();
         let mut space = Space::empty_positive(1, 1, 1);
-        space.set((0, 0, 0), &block).unwrap();
+        space.set([0, 0, 0], &block).unwrap();
         let mut body = Body {
             velocity: Vector3::new(2.0, 0.0, 0.0),
             flying: false,
@@ -96,7 +96,7 @@ mod tests {
         assert!((body.position.y - 1.5).abs() < 1e-6, "{:?}", body.position);
         assert_eq!(
             contacts,
-            vec![Contact::Block(CubeFace::new((0, 0, 0), Face7::PY))]
+            vec![Contact::Block(CubeFace::new([0, 0, 0], Face7::PY))]
         );
     }
 
@@ -109,7 +109,7 @@ mod tests {
         let block = make_slab(u, i32::from(RES) / 2, RES);
 
         let mut space = Space::empty_positive(1, 1, 1);
-        space.set((0, 0, 0), &block).unwrap();
+        space.set([0, 0, 0], &block).unwrap();
         let mut body = Body {
             velocity: Vector3::new(x_velocity, 0.0, 0.0),
             flying: false,
@@ -132,7 +132,7 @@ mod tests {
             matches!(
                 contacts[0],
                 Contact::Voxel {
-                    cube: GridPoint { x: 0, y: 0, z: 0 },
+                    cube: Cube::ORIGIN,
                     resolution: RES,
                     voxel: CubeFace {
                         cube: _,
@@ -163,7 +163,7 @@ mod tests {
     fn push_out_simple() {
         let [block] = make_some_blocks();
         let mut space = Space::empty_positive(1, 1, 1);
-        space.set((0, 0, 0), &block).unwrap();
+        space.set([0, 0, 0], &block).unwrap();
         let mut body = Body {
             position: Point3::new(1.25, 0.5, 0.5), // intersection of 0.25
             velocity: Vector3::zero(),

--- a/all-is-cubes/src/physics/body.rs
+++ b/all-is-cubes/src/physics/body.rs
@@ -560,33 +560,33 @@ mod tests {
         Body {
             flying: false,
             noclip: false,
-            ..Body::new_minimal((0., 2., 0.), Aab::new(-0.5, 0.5, -0.5, 0.5, -0.5, 0.5))
+            ..Body::new_minimal([0., 2., 0.], Aab::new(-0.5, 0.5, -0.5, 0.5, -0.5, 0.5))
         }
     }
 
     #[test]
     fn look_at() {
         let do_test = |direction, yaw, pitch| {
-            let mut body = Body::new_minimal((10., 0., 0.), Aab::ZERO);
+            let mut body = Body::new_minimal([10., 0., 0.], Aab::ZERO);
             body.look_at(Point3::new(10., 0., 0.) + Vector3::from(direction));
             println!("{direction:?} {yaw} {pitch}");
             assert_eq!(body.yaw, yaw);
             assert_eq!(body.pitch, pitch);
         };
 
-        do_test((0., 0., -1.), 0., 0.);
-        do_test((1., 0., -1.), 45., 0.);
-        do_test((1., 0., 0.), 90., 0.);
-        do_test((0., 0., 1.), 180., 0.);
-        do_test((-1., 0., 0.), 270., 0.);
+        do_test([0., 0., -1.], 0., 0.);
+        do_test([1., 0., -1.], 45., 0.);
+        do_test([1., 0., 0.], 90., 0.);
+        do_test([0., 0., 1.], 180., 0.);
+        do_test([-1., 0., 0.], 270., 0.);
 
         // TODO: would be tidier if this is 0 instead; revisit the math
         let exactly_vertical_yaw = 180.;
-        do_test((0., 1., 0.), exactly_vertical_yaw, -90.);
-        do_test((0., 1., -1.), 0., -45.);
-        do_test((0., 0., -1.), 0., 0.);
-        do_test((0., -1., -1.), 0., 45.);
-        do_test((0., -1., 0.), exactly_vertical_yaw, 90.);
+        do_test([0., 1., 0.], exactly_vertical_yaw, -90.);
+        do_test([0., 1., -1.], 0., -45.);
+        do_test([0., 0., -1.], 0., 0.);
+        do_test([0., -1., -1.], 0., 45.);
+        do_test([0., -1., 0.], exactly_vertical_yaw, 90.);
     }
 
     #[test]

--- a/all-is-cubes/src/raytracer/text.rs
+++ b/all-is-cubes/src/raytracer/text.rs
@@ -141,12 +141,12 @@ mod tests {
     fn print_space_test() {
         let mut space = Space::empty_positive(3, 1, 1);
         let [b0, b1, b2] = make_some_blocks();
-        space.set((0, 0, 0), &b0).unwrap();
-        space.set((1, 0, 0), &b1).unwrap();
-        space.set((2, 0, 0), &b2).unwrap();
+        space.set([0, 0, 0], &b0).unwrap();
+        space.set([1, 0, 0], &b1).unwrap();
+        space.set([2, 0, 0], &b2).unwrap();
 
         let mut output = String::new();
-        print_space_impl(&space, (1., 1., 1.), |s| output += s);
+        print_space_impl(&space, [1., 1., 1.], |s| output += s);
         print!("{output}");
         pretty_assertions::assert_eq!(
             output,
@@ -216,7 +216,7 @@ mod tests {
         space.set([1, 0, 0], &partial_block).unwrap();
 
         let mut output = String::new();
-        print_space_impl(&space, (1., 1., 1.), |s| output += s);
+        print_space_impl(&space, [1., 1., 1.], |s| output += s);
         print!("{output}");
         pretty_assertions::assert_eq!(
             output,

--- a/all-is-cubes/src/raytracer/updating.rs
+++ b/all-is-cubes/src/raytracer/updating.rs
@@ -7,7 +7,7 @@ use crate::block::AIR;
 use crate::camera::GraphicsOptions;
 use crate::content::palette;
 use crate::listen::{Listen as _, ListenableSource, Listener};
-use crate::math::GridPoint;
+use crate::math::Cube;
 use crate::raytracer::{RtBlockData, RtOptionsRef, SpaceRaytracer, TracingBlock, TracingCubeData};
 use crate::space::{BlockIndex, Space, SpaceChange};
 use crate::universe::{RefError, URef};
@@ -166,7 +166,7 @@ struct SrtTodo {
 
     // TODO: Benchmark using a BitVec instead.
     blocks: HashSet<BlockIndex>,
-    cubes: HashSet<GridPoint>,
+    cubes: HashSet<Cube>,
 }
 
 /// [`Listener`] adapter for [`SpaceRendererTodo`].

--- a/all-is-cubes/src/space/builder.rs
+++ b/all-is-cubes/src/space/builder.rs
@@ -324,7 +324,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Space {
 #[cfg(test)]
 mod tests {
     use crate::content::make_some_blocks;
-    use crate::math::{GridPoint, Rgba};
+    use crate::math::{Cube, Rgba};
 
     use super::*;
 
@@ -375,7 +375,7 @@ mod tests {
 
     #[test]
     fn palette_err_too_long() {
-        let bounds = GridAab::single_cube(GridPoint::new(0, 0, 0));
+        let bounds = GridAab::ORIGIN_CUBE;
         assert_eq!(
             Space::builder(bounds)
                 .palette_and_contents(vec![AIR; 65537], GridArray::from_element(2), None,)
@@ -386,14 +386,14 @@ mod tests {
 
     #[test]
     fn palette_err_too_short_for_contents() {
-        let bounds = GridAab::single_cube(GridPoint::new(0, 0, 0));
+        let bounds = GridAab::ORIGIN_CUBE;
         assert_eq!(
             Space::builder(bounds)
                 .palette_and_contents(&mut [AIR].into_iter(), GridArray::from_element(2), None,)
                 .unwrap_err(),
             PaletteError::Index {
                 index: 2,
-                cube: GridPoint::new(0, 0, 0),
+                cube: Cube::new(0, 0, 0),
                 palette_len: 1
             }
         );
@@ -402,12 +402,12 @@ mod tests {
     #[test]
     fn palette_err_contents_wrong_bounds() {
         assert_eq!(
-            Space::builder(GridAab::single_cube(GridPoint::new(1, 0, 0)))
+            Space::builder(GridAab::single_cube(Cube::new(1, 0, 0)))
                 .palette_and_contents([AIR], GridArray::from_element(0), None)
                 .unwrap_err(),
             PaletteError::WrongDataBounds {
-                expected: GridAab::single_cube(GridPoint::new(1, 0, 0)),
-                actual: GridAab::single_cube(GridPoint::new(0, 0, 0)),
+                expected: GridAab::single_cube(Cube::new(1, 0, 0)),
+                actual: GridAab::ORIGIN_CUBE,
             }
         );
     }

--- a/all-is-cubes/src/space/palette.rs
+++ b/all-is-cubes/src/space/palette.rs
@@ -525,7 +525,7 @@ pub enum PaletteError {
     )]
     Index {
         index: BlockIndex,
-        cube: math::GridPoint,
+        cube: math::Cube,
         palette_len: usize,
     },
 

--- a/all-is-cubes/src/universe/universe_txn.rs
+++ b/all-is-cubes/src/universe/universe_txn.rs
@@ -643,7 +643,7 @@ mod tests {
 
     use super::*;
     use crate::content::make_some_blocks;
-    use crate::math::GridPoint;
+    use crate::math::Cube;
     use crate::space::CubeConflict;
     use crate::space::Space;
     use crate::space::SpaceTransaction;
@@ -724,16 +724,19 @@ mod tests {
 
         let UniverseConflict::Member(MapConflict {
             key,
-            conflict: MemberConflict::Modify(
-                ModifyMemberConflict(AnyTransactionConflict::Space(SpaceTransactionConflict::Cube {
-                    cube: GridPoint { x: 0, y: 0, z: 0 },
-                    conflict: CubeConflict {
-                        old: false,
-                        new: true,
+            conflict:
+                MemberConflict::Modify(ModifyMemberConflict(AnyTransactionConflict::Space(
+                    SpaceTransactionConflict::Cube {
+                        cube: Cube { x: 0, y: 0, z: 0 },
+                        conflict:
+                            CubeConflict {
+                                old: false,
+                                new: true,
+                            },
                     },
-                }))
-            )
-        }) = error else {
+                ))),
+        }) = error
+        else {
             panic!("not as expected: {error:?}");
         };
         assert_eq!(key, s.name());

--- a/all-is-cubes/src/util.rs
+++ b/all-is-cubes/src/util.rs
@@ -99,7 +99,8 @@ impl<T: CustomFormat<ConciseDebug>, const N: usize> CustomFormat<ConciseDebug> f
 // TODO: Macro time?
 impl<S: Debug> CustomFormat<ConciseDebug> for Point3<S> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>, _: ConciseDebug) -> fmt::Result {
-        write!(fmt, "({:+.3?}, {:+.3?}, {:+.3?})", self.x, self.y, self.z)
+        let Self { x, y, z } = self;
+        write!(fmt, "({x:+.3?}, {y:+.3?}, {z:+.3?})")
     }
 }
 

--- a/test-renderers/src/test_cases.rs
+++ b/test-renderers/src/test_cases.rs
@@ -15,7 +15,7 @@ use all_is_cubes::cgmath::{EuclideanSpace as _, One, Point2, Point3, Vector2, Ve
 use all_is_cubes::character::{Character, Spawn};
 use all_is_cubes::listen::{ListenableCell, ListenableSource};
 use all_is_cubes::math::{
-    Face6, FreeCoordinate, GridAab, GridArray, GridCoordinate, GridPoint, GridRotation, GridVector,
+    Cube, Face6, FreeCoordinate, GridAab, GridArray, GridCoordinate, GridRotation, GridVector,
     NotNan, Rgb, Rgba,
 };
 use all_is_cubes::space::{LightPhysics, Space, SpaceBuilder};
@@ -870,15 +870,15 @@ async fn antialias_test_universe() -> Arc<Universe> {
     let [voxel_block_2] = make_some_voxel_blocks(&mut universe);
     let voxel_block_2 = voxel_block_2.rotate(GridRotation::RZyX);
 
-    let solid_block_pattern = |p: GridPoint| -> Option<&Block> {
-        Some(if (p.x + p.y + p.z).rem_euclid(2) == 0 {
+    let solid_block_pattern = |cube: Cube| -> Option<&Block> {
+        Some(if (cube.x + cube.y + cube.z).rem_euclid(2) == 0 {
             &large_block
         } else {
             &neutral
         })
     };
-    let voxel_block_pattern = |p: GridPoint| -> Option<&Block> {
-        let mod3 = p.to_vec().map(|c| c.rem_euclid(3));
+    let voxel_block_pattern = |cube: Cube| -> Option<&Block> {
+        let mod3 = cube.lower_bounds().map(|c| c.rem_euclid(3));
         Some(if mod3.x == 0 && mod3.z == 2 {
             &voxel_block_2
         } else {


### PR DESCRIPTION
This type distinguishes “an integer-valued point” from “a unit cube”, which should reduce the incidence of off-by-one errors and incorrect rotations. It allows us to have custom methods and to reduce the dependence on `cgmath`.
