### PR TITLE
Update `wgpu` dep to 0.19.0. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -711,7 +711,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -870,7 +870,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1002,7 +1002,7 @@ checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1235,7 +1235,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1273,10 +1273,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "com-rs"
-version = "0.2.1"
+name = "com"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf43edc576402991846b093a7ca18a3477e0ef9c588cde84964b5d3e43016642"
+checksum = "7e17887fd17353b65b1b2ef1c526c83e26cd72e74f598a8dc1bee13a48f3d9f6"
+dependencies = [
+ "com_macros",
+]
+
+[[package]]
+name = "com_macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d375883580a668c7481ea6631fc1a8863e33cc335bf56bfad8d7e6d4b04b13a5"
+dependencies = [
+ "com_macros_support",
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "com_macros_support"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad899a1087a9296d5644792d7cb72b8e34c1bec8e7d4fbc002230169a6e8710c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "combine"
@@ -1601,8 +1626,7 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 [[package]]
 name = "d3d12"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16e44ab292b1dddfdaf7be62cfd8877df52f2f3fde5858d95bab606be259f20"
+source = "git+https://github.com/gfx-rs/wgpu/?branch=trunk#2512b2dae1e8a298bff92ce591adbaa6a3749ee2"
 dependencies = [
  "bitflags 2.4.1",
  "libloading 0.8.1",
@@ -1643,7 +1667,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1718,7 +1742,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1885,7 +1909,7 @@ checksum = "f95e2801cd355d4a1a3e3953ce6ee5ae9603a5c833455343a8bfe3f44d418246"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1998,7 +2022,7 @@ dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2099,7 +2123,6 @@ checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
 dependencies = [
  "futures-core",
  "futures-sink",
- "nanorand",
  "spin",
 ]
 
@@ -2127,7 +2150,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2241,7 +2264,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2378,8 +2401,7 @@ dependencies = [
 [[package]]
 name = "glow"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "886c2a30b160c4c6fec8f987430c26b526b7988ca71f664e6a699ddf6f9601e4"
+source = "git+https://github.com/grovesNL/glow.git?rev=29ff917a2b2ff7ce0a81b2cc5681de6d4735b36e#29ff917a2b2ff7ce0a81b2cc5681de6d4735b36e"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -2411,7 +2433,7 @@ dependencies = [
  "inflections",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2456,16 +2478,15 @@ dependencies = [
 
 [[package]]
 name = "gpu-allocator"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fe17c8a05d60c38c0a4e5a3c802f2f1ceb66b76c67d96ffb34bef0475a7fad"
+checksum = "6f56f6318968d03c18e1bcf4857ff88c61157e9da8e47c5f29055d60e1228884"
 dependencies = [
- "backtrace",
  "log",
  "presser",
  "thiserror",
  "winapi",
- "windows 0.51.1",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -2575,14 +2596,14 @@ dependencies = [
 
 [[package]]
 name = "hassle-rs"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1397650ee315e8891a0df210707f0fc61771b0cc518c3023896064c5407cb3b0"
+checksum = "af2a7e73e1f34c48da31fb668a907f250794837e08faa144fd24f0b8b741e890"
 dependencies = [
- "bitflags 1.3.2",
- "com-rs",
+ "bitflags 2.4.1",
+ "com",
  "libc",
- "libloading 0.7.4",
+ "libloading 0.8.1",
  "thiserror",
  "widestring",
  "winapi",
@@ -3393,8 +3414,7 @@ checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
 [[package]]
 name = "naga"
 version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae585df4b6514cf8842ac0f1ab4992edc975892704835b549cf818dc0191249e"
+source = "git+https://github.com/gfx-rs/wgpu/?branch=trunk#2512b2dae1e8a298bff92ce591adbaa6a3749ee2"
 dependencies = [
  "bit-set",
  "bitflags 2.4.1",
@@ -3408,15 +3428,6 @@ dependencies = [
  "termcolor",
  "thiserror",
  "unicode-xid",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.11",
 ]
 
 [[package]]
@@ -3463,7 +3474,6 @@ dependencies = [
  "log",
  "ndk-sys 0.5.0+25.2.9519653",
  "num_enum 0.7.1",
- "raw-window-handle 0.5.2",
  "raw-window-handle 0.6.0",
  "thiserror",
 ]
@@ -3597,7 +3607,7 @@ checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3680,7 +3690,7 @@ dependencies = [
  "proc-macro-crate 2.0.1",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3996,7 +4006,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4188,7 +4198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4213,9 +4223,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
@@ -4267,9 +4277,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -4715,7 +4725,7 @@ dependencies = [
  "re_log",
  "re_tracing",
  "rust-format",
- "syn 2.0.41",
+ "syn 2.0.48",
  "tempfile",
  "unindent",
  "xshell 0.2.5",
@@ -5238,7 +5248,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5270,7 +5280,7 @@ checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5400,7 +5410,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acee08041c5de3d5048c8b3f6f13fafb3026b24ba43c6a695a0c76179b844369"
 dependencies = [
  "log",
- "termcolor",
  "time",
 ]
 
@@ -5525,12 +5534,11 @@ dependencies = [
 
 [[package]]
 name = "spirv"
-version = "0.2.0+1.5.4"
+version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830"
+checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 1.3.2",
- "num-traits",
+ "bitflags 2.4.1",
 ]
 
 [[package]]
@@ -5603,7 +5611,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5619,9 +5627,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.41"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5690,9 +5698,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
@@ -5742,22 +5750,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5844,7 +5852,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5967,7 +5975,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -6224,7 +6232,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -6258,7 +6266,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6284,9 +6292,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6311,18 +6319,17 @@ checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 [[package]]
 name = "wgpu"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e7d227c9f961f2061c26f4cb0fbd4df0ef37e056edd0931783599d6c94ef24"
+source = "git+https://github.com/gfx-rs/wgpu/?branch=trunk#2512b2dae1e8a298bff92ce591adbaa6a3749ee2"
 dependencies = [
  "arrayvec",
  "cfg-if",
- "flume",
+ "cfg_aliases",
  "js-sys",
  "log",
  "naga",
  "parking_lot",
  "profiling",
- "raw-window-handle 0.5.2",
+ "raw-window-handle 0.6.0",
  "smallvec",
  "static_assertions",
  "wasm-bindgen",
@@ -6335,19 +6342,20 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef91c1d62d1e9e81c79e600131a258edf75c9531cbdbde09c44a011a47312726"
+version = "0.18.0"
+source = "git+https://github.com/gfx-rs/wgpu/?branch=trunk#2512b2dae1e8a298bff92ce591adbaa6a3749ee2"
 dependencies = [
  "arrayvec",
  "bit-vec",
  "bitflags 2.4.1",
  "codespan-reporting",
+ "indexmap 2.1.0",
  "log",
  "naga",
+ "once_cell",
  "parking_lot",
  "profiling",
- "raw-window-handle 0.5.2",
+ "raw-window-handle 0.6.0",
  "rustc-hash",
  "smallvec",
  "thiserror",
@@ -6358,9 +6366,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84ecc802da3eb67b4cf3dd9ea6fe45bbb47ef13e6c49c5c3240868a9cc6cdd9"
+version = "0.18.0"
+source = "git+https://github.com/gfx-rs/wgpu/?branch=trunk#2512b2dae1e8a298bff92ce591adbaa6a3749ee2"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -6388,7 +6395,7 @@ dependencies = [
  "parking_lot",
  "profiling",
  "range-alloc",
- "raw-window-handle 0.5.2",
+ "raw-window-handle 0.6.0",
  "renderdoc-sys",
  "rustc-hash",
  "smallvec",
@@ -6412,8 +6419,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5ed5f0edf0de351fe311c53304986315ce866f394a2e6df0c4b3c70774bcdd"
+source = "git+https://github.com/gfx-rs/wgpu/?branch=trunk#2512b2dae1e8a298bff92ce591adbaa6a3749ee2"
 dependencies = [
  "bitflags 2.4.1",
  "js-sys",
@@ -6477,31 +6483,12 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.51.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
-dependencies = [
- "windows-core 0.51.1",
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
- "windows-core 0.52.0",
+ "windows-core",
  "windows-targets 0.52.0",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.51.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6736,7 +6723,7 @@ dependencies = [
  "once_cell",
  "orbclient",
  "percent-encoding",
- "raw-window-handle 0.5.2",
+ "raw-window-handle 0.6.0",
  "redox_syscall 0.3.5",
  "rustix 0.38.28",
  "smol_str",
@@ -6993,7 +6980,7 @@ checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,6 @@ dependencies = [
  "resource",
  "thiserror",
  "tokio",
- "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "web-time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,7 @@ dependencies = [
  "tokio",
  "trycmd",
  "unicode-width",
+ "wgpu",
  "winit",
  "yield-progress",
 ]
@@ -1625,8 +1626,9 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
 name = "d3d12"
-version = "0.7.0"
-source = "git+https://github.com/gfx-rs/wgpu/?branch=trunk#2512b2dae1e8a298bff92ce591adbaa6a3749ee2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e3d747f100290a1ca24b752186f61f6637e1deffe3bf6320de6fcb29510a307"
 dependencies = [
  "bitflags 2.4.1",
  "libloading 0.8.1",
@@ -1873,7 +1875,7 @@ checksum = "3fe2568f851fd6144a45fa91cfed8fe5ca8fc0b56ba6797bfc1ed2771b90e37c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2123,6 +2125,7 @@ checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
 dependencies = [
  "futures-core",
  "futures-sink",
+ "nanorand",
  "spin",
 ]
 
@@ -2400,8 +2403,9 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.13.0"
-source = "git+https://github.com/grovesNL/glow.git?rev=29ff917a2b2ff7ce0a81b2cc5681de6d4735b36e#29ff917a2b2ff7ce0a81b2cc5681de6d4735b36e"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -3036,9 +3040,9 @@ checksum = "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e"
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3414,7 +3418,27 @@ checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
 [[package]]
 name = "naga"
 version = "0.14.2"
-source = "git+https://github.com/gfx-rs/wgpu/?branch=trunk#2512b2dae1e8a298bff92ce591adbaa6a3749ee2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae585df4b6514cf8842ac0f1ab4992edc975892704835b549cf818dc0191249e"
+dependencies = [
+ "bit-set",
+ "bitflags 2.4.1",
+ "codespan-reporting",
+ "hexf-parse",
+ "indexmap",
+ "log",
+ "num-traits",
+ "rustc-hash",
+ "termcolor",
+ "thiserror",
+ "unicode-xid",
+]
+
+[[package]]
+name = "naga"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8878eb410fc90853da3908aebfe61d73d26d4437ef850b70050461f939509899"
 dependencies = [
  "bit-set",
  "bitflags 2.4.1",
@@ -3428,6 +3452,15 @@ dependencies = [
  "termcolor",
  "thiserror",
  "unicode-xid",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.11",
 ]
 
 [[package]]
@@ -3965,7 +3998,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4824,7 +4857,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "rend3"
 version = "0.3.0"
-source = "git+https://github.com/BVE-Reborn/rend3/?rev=a68c76a2809cf545484d727e32a222400134d085#a68c76a2809cf545484d727e32a222400134d085"
+source = "git+https://github.com/kpreid/rend3/?branch=wgpu19#2f3f06de2778dff02326bf9bdd59440a85c7bde5"
 dependencies = [
  "arrayvec",
  "bimap",
@@ -4858,7 +4891,7 @@ dependencies = [
 [[package]]
 name = "rend3-gltf"
 version = "0.3.0"
-source = "git+https://github.com/BVE-Reborn/rend3/?rev=a68c76a2809cf545484d727e32a222400134d085#a68c76a2809cf545484d727e32a222400134d085"
+source = "git+https://github.com/kpreid/rend3/?branch=wgpu19#2f3f06de2778dff02326bf9bdd59440a85c7bde5"
 dependencies = [
  "arrayvec",
  "base64 0.21.5",
@@ -4878,7 +4911,7 @@ dependencies = [
 [[package]]
 name = "rend3-routine"
 version = "0.3.0"
-source = "git+https://github.com/BVE-Reborn/rend3/?rev=a68c76a2809cf545484d727e32a222400134d085#a68c76a2809cf545484d727e32a222400134d085"
+source = "git+https://github.com/kpreid/rend3/?branch=wgpu19#2f3f06de2778dff02326bf9bdd59440a85c7bde5"
 dependencies = [
  "arrayvec",
  "bitflags 2.4.1",
@@ -4888,7 +4921,7 @@ dependencies = [
  "flume",
  "glam",
  "log",
- "naga",
+ "naga 0.14.2",
  "ordered-float",
  "parking_lot",
  "profiling",
@@ -4903,7 +4936,7 @@ dependencies = [
 [[package]]
 name = "rend3-types"
 version = "0.3.0"
-source = "git+https://github.com/BVE-Reborn/rend3/?rev=a68c76a2809cf545484d727e32a222400134d085#a68c76a2809cf545484d727e32a222400134d085"
+source = "git+https://github.com/kpreid/rend3/?branch=wgpu19#2f3f06de2778dff02326bf9bdd59440a85c7bde5"
 dependencies = [
  "bitflags 2.4.1",
  "bytemuck",
@@ -5064,7 +5097,7 @@ dependencies = [
  "quote",
  "rust-embed-utils",
  "shellexpand",
- "syn 2.0.41",
+ "syn 2.0.48",
  "walkdir",
 ]
 
@@ -6213,9 +6246,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -6223,9 +6256,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
  "bumpalo",
  "log",
@@ -6238,9 +6271,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6250,9 +6283,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6260,9 +6293,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6273,9 +6306,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "wasm-streams"
@@ -6292,9 +6325,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6318,15 +6351,16 @@ checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "wgpu"
-version = "0.18.0"
-source = "git+https://github.com/gfx-rs/wgpu/?branch=trunk#2512b2dae1e8a298bff92ce591adbaa6a3749ee2"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe9a310dcf2e6b85f00c46059aaeaf4184caa8e29a1ecd4b7a704c3482332d"
 dependencies = [
  "arrayvec",
  "cfg-if",
  "cfg_aliases",
  "js-sys",
  "log",
- "naga",
+ "naga 0.19.0",
  "parking_lot",
  "profiling",
  "raw-window-handle 0.6.0",
@@ -6342,16 +6376,18 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.18.0"
-source = "git+https://github.com/gfx-rs/wgpu/?branch=trunk#2512b2dae1e8a298bff92ce591adbaa6a3749ee2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b15e451d4060ada0d99a64df44e4d590213496da7c4f245572d51071e8e30ed"
 dependencies = [
  "arrayvec",
  "bit-vec",
  "bitflags 2.4.1",
+ "cfg_aliases",
  "codespan-reporting",
- "indexmap 2.1.0",
+ "indexmap",
  "log",
- "naga",
+ "naga 0.19.0",
  "once_cell",
  "parking_lot",
  "profiling",
@@ -6366,8 +6402,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.18.0"
-source = "git+https://github.com/gfx-rs/wgpu/?branch=trunk#2512b2dae1e8a298bff92ce591adbaa6a3749ee2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f259ceb56727fb097da108d92f8a5cbdb5b74a77f9e396bd43626f67299d61"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -6375,6 +6412,7 @@ dependencies = [
  "bit-set",
  "bitflags 2.4.1",
  "block",
+ "cfg_aliases",
  "core-graphics-types",
  "d3d12",
  "glow",
@@ -6389,7 +6427,7 @@ dependencies = [
  "libloading 0.8.1",
  "log",
  "metal",
- "naga",
+ "naga 0.19.0",
  "objc",
  "once_cell",
  "parking_lot",
@@ -6408,18 +6446,20 @@ dependencies = [
 
 [[package]]
 name = "wgpu-profiler"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdc78911971a06b86a57a9a8e1c861fbc90c62dcbc96bff0b2831c1e853b7bd"
+checksum = "86a65ce8a137d0e2fdbb762c5e72127dbb3527ef0628c28c77b84f122634b57b"
 dependencies = [
+ "parking_lot",
  "thiserror",
  "wgpu",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "0.18.0"
-source = "git+https://github.com/gfx-rs/wgpu/?branch=trunk#2512b2dae1e8a298bff92ce591adbaa6a3749ee2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "895fcbeb772bfb049eb80b2d6e47f6c9af235284e9703c96fc0218a42ffd5af2"
 dependencies = [
  "bitflags 2.4.1",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ rendiff = { version = "0.1.0" }
 send_wrapper = "0.6.0"
 serde = { version = "1.0.160", default-features = false, features = ["derive"] }
 serde_json = "1.0.79"
-simplelog = "0.12.0"
+simplelog = { version = "0.12.0", default-features = false, features = ["local-offset"] }
 snapbox = "0.4.11" # keep in sync with `trycmd`
 strum = { version = "0.25.0", default-features = false, features = ["derive"] }
 tempfile = "3.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ macro_rules_attribute = "0.2.0"
 manyfmt = "0.1.0"
 mutants = "0.0.3"
 num-traits = { version = "0.2.15", default-features = false }
-once_cell = "1.18.0"
+once_cell = "1.19.0"
 ordered-float = { version = "4.2.0", default-features = false }
 pollster = { version = "0.3.0", default-features = false }
 polonius-the-crab = { version = "0.4.1" }
@@ -88,13 +88,13 @@ simplelog = { version = "0.12.0", default-features = false, features = ["local-o
 snapbox = "0.4.11" # keep in sync with `trycmd`
 strum = { version = "0.25.0", default-features = false, features = ["derive"] }
 tempfile = "3.3.0"
-thiserror = "1.0.40"
+thiserror = "1.0.56"
 # Tokio is used for async test-running and for certain binaries.
 # The library crates do not require Tokio.
 tokio = { version = "1.28.0", default-features = false }
 trycmd = "0.14.1" # keep in sync with `snapbox`
 unicode-segmentation = { version = "1.10.1", default-features = false }
-wasm-bindgen-futures = "0.4.34"
+wasm-bindgen-futures = "0.4.40"
 web-time = "0.2.3"
 wgpu = { version = "0.19.1", default-features = false, features = ["wgsl"] }
 yield-progress = { version = "0.1.5", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,8 +96,7 @@ trycmd = "0.14.1" # keep in sync with `snapbox`
 unicode-segmentation = { version = "1.10.1", default-features = false }
 wasm-bindgen-futures = "0.4.34"
 web-time = "0.2.3"
-# Note: "expose_ids" feature is not needed globally but is enabled to avoid compiling two versions
-wgpu = { version = "0.18.0", features = ["expose-ids"] }
+wgpu = { version = "0.19.1", default-features = false, features = ["wgsl"] }
 yield-progress = { version = "0.1.5", default-features = false }
 
 # Note: Lints are also necessarily redefined in the workspaces other than this one.
@@ -171,4 +170,4 @@ overflow-checks = true
 [patch.crates-io]
 # Here are some patches we might want to apply for development:
 #
-# wgpu = { git = "https://github.com/gfx-rs/wgpu/", branch = "master" }
+# wgpu = { git = "https://github.com/gfx-rs/wgpu/", branch = "trunk" }

--- a/all-is-cubes-desktop/Cargo.toml
+++ b/all-is-cubes-desktop/Cargo.toml
@@ -55,9 +55,11 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }
 ratatui = { version = "0.25.0", default-features = false, features = ["crossterm"] }
 unicode-width = { version = "0.1.9", default-features = false }
+# We have no true direct dependency on wgpu, but do need to select backends.
+# (As of wgpu 0.19, Vulkan is implicitly enabled on Linux
+wgpu = { workspace = true, features = ["dx12", "metal"] }
 # Note on feature selection: winit requires either "x11" or "wayland" to build at all on Linux, which is harmless elsewhere. I picked x11 because it should be the most compatible.
-# TODO: drop rwh_05 when wgpu is updated
-winit = { version = "0.29.2", default-features = false, features = ["x11", "rwh_05"] }
+winit = { version = "0.29.2", default-features = false, features = ["x11", "rwh_06"] }
 # Enable the log_hiccups feature
 yield-progress = { workspace = true, features = ["log_hiccups"] }
 

--- a/all-is-cubes-desktop/src/bin/all-is-cubes/main.rs
+++ b/all-is-cubes-desktop/src/bin/all-is-cubes/main.rs
@@ -1,7 +1,7 @@
 //! Binary for All is Cubes desktop app.
 
 // Crate-specific lint settings. (General settings can be found in the workspace manifest.)
-// * This crate does not forbid(unsafe_code) because wgpu initialization requires it.
+#![forbid(unsafe_code)]
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};

--- a/all-is-cubes-desktop/src/lib.rs
+++ b/all-is-cubes-desktop/src/lib.rs
@@ -8,6 +8,9 @@
 //! so that additional development tools can reuse the same UI code. Use at your own risk.
 //! Documentation is lacking.
 
+// Crate-specific lint settings. (General settings can be found in the workspace manifest.)
+#![forbid(unsafe_code)]
+
 use std::time::Instant;
 
 use anyhow::Context as _;

--- a/all-is-cubes-desktop/src/logging.rs
+++ b/all-is-cubes-desktop/src/logging.rs
@@ -42,37 +42,34 @@ pub fn install(
     } = options;
     let kinds: HashSet<RerunDataKind> = HashSet::from_iter(kinds.iter().cloned());
 
-    let (max_level, stderr_logger): (log::LevelFilter, Option<simplelog::TermLogger>) =
-        if options.verbose || !suppress_unless_explicit {
-            // Note: Something like this log configuration also appears in other binaries.
-            // Unclear how to deduplicate since we don't want to have a library-level dep on
-            // simplelog. For now, just remember to consider updating other instances.
-            let logger = *simplelog::TermLogger::new(
-                match verbose {
-                    // TODO: When we're closer to 1.0, change the default level to `Info`
-                    false => Debug,
-                    true => Trace,
-                },
-                simplelog::ConfigBuilder::new()
-                    .set_target_level(Off)
-                    .set_location_level(Off)
-                    .set_time_level(if simplify_log_format { Off } else { Error })
-                    .add_filter_ignore_str("wgpu") // noisy
-                    .add_filter_ignore_str("naga") // noisy
-                    .add_filter_ignore_str("winit") // noisy at Trace level only
-                    .build(),
-                simplelog::TerminalMode::Stderr,
-                if simplify_log_format {
-                    simplelog::ColorChoice::Never
-                } else {
-                    simplelog::ColorChoice::Auto
-                },
-            );
+    let (max_level, stderr_logger): (
+        log::LevelFilter,
+        Option<simplelog::WriteLogger<std::io::Stderr>>,
+    ) = if options.verbose || !suppress_unless_explicit {
+        // Note: Something like this log configuration also appears in other binaries.
+        // Unclear how to deduplicate since we don't want to have a library-level dep on
+        // simplelog. For now, just remember to consider updating other instances.
+        let logger = *simplelog::WriteLogger::new(
+            match verbose {
+                // TODO: When we're closer to 1.0, change the default level to `Info`
+                false => Debug,
+                true => Trace,
+            },
+            simplelog::ConfigBuilder::new()
+                .set_target_level(Off)
+                .set_location_level(Off)
+                .set_time_level(if simplify_log_format { Off } else { Error })
+                .add_filter_ignore_str("wgpu") // noisy
+                .add_filter_ignore_str("naga") // noisy
+                .add_filter_ignore_str("winit") // noisy at Trace level only
+                .build(),
+            std::io::stderr(),
+        );
 
-            (simplelog::SharedLogger::level(&logger), Some(logger))
-        } else {
-            (Off, None)
-        };
+        (simplelog::SharedLogger::level(&logger), Some(logger))
+    } else {
+        (Off, None)
+    };
 
     // If we're going to construct a Rerun recording stream, because the user passed at least
     // one `--rerun=` arg, do so now.
@@ -123,7 +120,7 @@ pub fn install(
 
 /// [`log::Log`] implementation that [`install()`] registers globally.
 struct AicLogger {
-    stderr_logger: Option<simplelog::TermLogger>,
+    stderr_logger: Option<simplelog::WriteLogger<std::io::Stderr>>,
     #[cfg(feature = "rerun")]
     rerun_destination: rg::Destination,
 }

--- a/all-is-cubes-gpu/Cargo.toml
+++ b/all-is-cubes-gpu/Cargo.toml
@@ -78,7 +78,6 @@ gloo-timers = { version = "0.3.0", default-features = false, features = ["future
 # If we don't set this feature, it will try to access files at run time and fail
 # since web wasm has no std::fs.
 resource = { version = "0.5.0", features = ["force-static"] }
-wasm-bindgen = "0.2.89"
 wgpu = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/all-is-cubes-gpu/Cargo.toml
+++ b/all-is-cubes-gpu/Cargo.toml
@@ -67,8 +67,10 @@ rayon = { workspace = true, optional = true }
 resource = "0.5.0"
 thiserror = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
+# For initializing tests on web. (This is not a dev-dependency because some of said tests are not in this package.)
+web-sys = { version = "0.3.67", features = ["OffscreenCanvas"] }
 web-time = { workspace = true }
-wgpu = { workspace = true, optional = true, features = ["expose-ids"] }
+wgpu = { workspace = true, optional = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 # Used in the `poll` module to implement timeout
@@ -77,11 +79,7 @@ gloo-timers = { version = "0.3.0", default-features = false, features = ["future
 # since web wasm has no std::fs.
 resource = { version = "0.5.0", features = ["force-static"] }
 wasm-bindgen = "0.2.89"
-# For initializing tests on web.
-# Okay that this is a non-dev dependency because wgpu will have the same dep.
-web-sys = { version = "0.3.64", features = ["OffscreenCanvas"]}
-# Enable WebGL compatibility.
-wgpu = { workspace = true, optional = true, features = ["webgl"] }
+wgpu = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }

--- a/all-is-cubes-gpu/src/in_wgpu.rs
+++ b/all-is-cubes-gpu/src/in_wgpu.rs
@@ -71,7 +71,7 @@ impl all_is_cubes_mesh::dynamic::DynamicMeshTypes for WgpuMt {
 /// to draw on.
 #[derive(Debug)]
 pub struct SurfaceRenderer<I> {
-    surface: wgpu::Surface,
+    surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
     queue: wgpu::Queue,
 
@@ -88,7 +88,7 @@ impl<I: time::Instant> SurfaceRenderer<I> {
     /// and return an error if requesting the device fails.
     pub async fn new(
         cameras: StandardCameras,
-        surface: wgpu::Surface,
+        surface: wgpu::Surface<'static>,
         adapter: &wgpu::Adapter,
     ) -> Result<Self, GraphicsResourceError> {
         let (device, queue) = adapter
@@ -296,8 +296,8 @@ impl<I: time::Instant> EverythingRenderer<I> {
     /// A device descriptor suitable for the expectations of [`EverythingRenderer`].
     pub fn device_descriptor(available_limits: wgpu::Limits) -> wgpu::DeviceDescriptor<'static> {
         wgpu::DeviceDescriptor {
-            features: wgpu::Features::empty(),
-            limits: wgpu::Limits {
+            required_features: wgpu::Features::empty(),
+            required_limits: wgpu::Limits {
                 max_inter_stage_shader_components: 32, // number used by blocks-and-lines shader
                 ..wgpu::Limits::downlevel_webgl2_defaults().using_resolution(available_limits)
             },
@@ -322,6 +322,7 @@ impl<I: time::Instant> EverythingRenderer<I> {
             width: viewport.framebuffer_size.x.max(1),
             height: viewport.framebuffer_size.y.max(1),
             present_mode: wgpu::PresentMode::Fifo,
+            desired_maximum_frame_latency: 2,
             alpha_mode: wgpu::CompositeAlphaMode::Auto,
         };
 

--- a/all-is-cubes-gpu/src/in_wgpu/init.rs
+++ b/all-is-cubes-gpu/src/in_wgpu/init.rs
@@ -29,7 +29,7 @@ pub async fn create_instance_and_adapter_for_test(
     let surface = {
         // size shouldn't matter; use a funny noticeable number in case it turns out to
         let canvas = web_sys::OffscreenCanvas::new(143, 217).unwrap();
-        match instance.create_surface_from_offscreen_canvas(canvas) {
+        match instance.create_surface(wgpu::SurfaceTarget::OffscreenCanvas(canvas)) {
             Ok(surface) => Some(surface),
             // If we can't make a surface then we can't make an adapter.
             Err(_) => return (instance, None),
@@ -141,7 +141,7 @@ where
     let format = texture.format();
     let size_of_texel = components * std::mem::size_of::<C>();
     assert_eq!(
-        (format.block_size(None), format.block_dimensions()),
+        (format.block_copy_size(None), format.block_dimensions()),
         (Some(size_of_texel as u32), (1, 1)),
         "Texture format does not match requested size",
     );

--- a/all-is-cubes-gpu/src/in_wgpu/poll.rs
+++ b/all-is-cubes-gpu/src/in_wgpu/poll.rs
@@ -102,7 +102,7 @@ async fn polling_task(rx: flume::Receiver<Weak<wgpu::Device>>) {
                         wgpu::Maintain::Poll
                     };
 
-                    let queue_empty = device.poll(maintain);
+                    let queue_empty = device.poll(maintain).is_queue_empty();
                     if queue_empty {
                         to_drop.push(device_ref.clone());
                     }

--- a/all-is-cubes-gpu/src/in_wgpu/shader_testing.rs
+++ b/all-is-cubes-gpu/src/in_wgpu/shader_testing.rs
@@ -66,6 +66,7 @@ where
                 width: output_viewport.framebuffer_size.x,
                 height: output_viewport.framebuffer_size.y,
                 present_mode: wgpu::PresentMode::Fifo,
+                desired_maximum_frame_latency: 2,
                 alpha_mode: wgpu::CompositeAlphaMode::Auto,
             },
             FbtFeatures::new(adapter),

--- a/all-is-cubes-server/src/bin/aic-server.rs
+++ b/all-is-cubes-server/src/bin/aic-server.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // Unclear how to deduplicate since we don't want to have a library-level dep on
     // simplelog. For now, just remember to consider updating other instances.
     use simplelog::LevelFilter::{Debug, Off, Trace};
-    simplelog::TermLogger::init(
+    simplelog::WriteLogger::init(
         match verbose {
             false => Debug,
             true => Trace,
@@ -61,8 +61,7 @@ async fn main() -> Result<(), anyhow::Error> {
             .add_filter_ignore_str("hyper") // noisy
             .add_filter_ignore_str("mio") // uninteresting
             .build(),
-        simplelog::TerminalMode::Stderr,
-        simplelog::ColorChoice::Auto,
+        std::io::stderr(),
     )?;
 
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port.unwrap_or(0)));

--- a/all-is-cubes-wasm/Cargo.lock
+++ b/all-is-cubes-wasm/Cargo.lock
@@ -99,7 +99,6 @@ dependencies = [
  "rand_xoshiro",
  "resource",
  "thiserror",
- "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "web-time",

--- a/all-is-cubes-wasm/Cargo.lock
+++ b/all-is-cubes-wasm/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,21 +239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
-name = "backtrace"
-version = "0.3.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide 0.7.1",
- "object",
- "rustc-demangle",
-]
-
-[[package]]
 name = "base64"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,7 +312,7 @@ checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -361,6 +337,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,10 +359,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
-name = "com-rs"
-version = "0.2.1"
+name = "com"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf43edc576402991846b093a7ca18a3477e0ef9c588cde84964b5d3e43016642"
+checksum = "7e17887fd17353b65b1b2ef1c526c83e26cd72e74f598a8dc1bee13a48f3d9f6"
+dependencies = [
+ "com_macros",
+]
+
+[[package]]
+name = "com_macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d375883580a668c7481ea6631fc1a8863e33cc335bf56bfad8d7e6d4b04b13a5"
+dependencies = [
+ "com_macros_support",
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "com_macros_support"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad899a1087a9296d5644792d7cb72b8e34c1bec8e7d4fbc002230169a6e8710c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "console_error_panic_hook"
@@ -445,17 +452,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "d3d12"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16e44ab292b1dddfdaf7be62cfd8877df52f2f3fde5858d95bab606be259f20"
-dependencies = [
- "bitflags 2.4.1",
- "libloading 0.8.1",
- "winapi",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,7 +459,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -548,7 +544,7 @@ dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -593,7 +589,6 @@ checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
 dependencies = [
  "futures-core",
  "futures-sink",
- "nanorand",
  "spin",
 ]
 
@@ -621,7 +616,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -669,7 +664,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -726,12 +721,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
-
-[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "886c2a30b160c4c6fec8f987430c26b526b7988ca71f664e6a699ddf6f9601e4"
+checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -775,7 +764,7 @@ dependencies = [
  "inflections",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -820,11 +809,10 @@ dependencies = [
 
 [[package]]
 name = "gpu-allocator"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fe17c8a05d60c38c0a4e5a3c802f2f1ceb66b76c67d96ffb34bef0475a7fad"
+checksum = "6f56f6318968d03c18e1bcf4857ff88c61157e9da8e47c5f29055d60e1228884"
 dependencies = [
- "backtrace",
  "log",
  "presser",
  "thiserror",
@@ -875,14 +863,14 @@ dependencies = [
 
 [[package]]
 name = "hassle-rs"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1397650ee315e8891a0df210707f0fc61771b0cc518c3023896064c5407cb3b0"
+checksum = "af2a7e73e1f34c48da31fb668a907f250794837e08faa144fd24f0b8b741e890"
 dependencies = [
- "bitflags 1.3.2",
- "com-rs",
+ "bitflags 2.4.1",
+ "com",
  "libc",
- "libloading 0.7.4",
+ "libloading 0.8.1",
  "thiserror",
  "widestring",
  "winapi",
@@ -971,9 +959,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1147,9 +1135,9 @@ checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
 
 [[package]]
 name = "naga"
-version = "0.14.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae585df4b6514cf8842ac0f1ab4992edc975892704835b549cf818dc0191249e"
+checksum = "8878eb410fc90853da3908aebfe61d73d26d4437ef850b70050461f939509899"
 dependencies = [
  "bit-set",
  "bitflags 2.4.1",
@@ -1163,15 +1151,6 @@ dependencies = [
  "termcolor",
  "thiserror",
  "unicode-xid",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.11",
 ]
 
 [[package]]
@@ -1269,15 +1248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "object"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1414,9 +1384,9 @@ checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
@@ -1429,9 +1399,9 @@ checksum = "1de09527cd2ea2c2d59fb6c2f8c1ab8c71709ed9d1b6d60b0e1c9fbb6fdcb33c"
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1534,16 +1504,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "range-alloc"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
-
-[[package]]
 name = "raw-window-handle"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
+checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
 
 [[package]]
 name = "rectangle-pack"
@@ -1571,12 +1535,6 @@ name = "resource"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11a7f6703c396037a02da99195e49138c37f3cc5146cb95f2f7d26debc0c5622"
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -1631,7 +1589,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1653,7 +1611,7 @@ checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1697,12 +1655,11 @@ dependencies = [
 
 [[package]]
 name = "spirv"
-version = "0.2.0+1.5.4"
+version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830"
+checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 1.3.2",
- "num-traits",
+ "bitflags 2.4.1",
 ]
 
 [[package]]
@@ -1740,7 +1697,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1756,9 +1713,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.41"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1773,31 +1730,31 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "termcolor"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1844,9 +1801,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1854,24 +1811,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1881,9 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1891,22 +1848,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "wasm-bindgen-test"
@@ -1930,14 +1887,14 @@ checksum = "794645f5408c9a039fd09f4d113cdfb2e7eba5ff1956b07bcf701cf4b394fe89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1955,16 +1912,15 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e7d227c9f961f2061c26f4cb0fbd4df0ef37e056edd0931783599d6c94ef24"
+checksum = "0bfe9a310dcf2e6b85f00c46059aaeaf4184caa8e29a1ecd4b7a704c3482332d"
 dependencies = [
  "arrayvec",
  "cfg-if",
- "flume",
+ "cfg_aliases",
  "js-sys",
  "log",
- "naga",
  "parking_lot",
  "profiling",
  "raw-window-handle",
@@ -1980,16 +1936,19 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef91c1d62d1e9e81c79e600131a258edf75c9531cbdbde09c44a011a47312726"
+checksum = "6b15e451d4060ada0d99a64df44e4d590213496da7c4f245572d51071e8e30ed"
 dependencies = [
  "arrayvec",
  "bit-vec",
  "bitflags 2.4.1",
+ "cfg_aliases",
  "codespan-reporting",
+ "indexmap",
  "log",
  "naga",
+ "once_cell",
  "parking_lot",
  "profiling",
  "raw-window-handle",
@@ -2003,18 +1962,16 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84ecc802da3eb67b4cf3dd9ea6fe45bbb47ef13e6c49c5c3240868a9cc6cdd9"
+checksum = "11f259ceb56727fb097da108d92f8a5cbdb5b74a77f9e396bd43626f67299d61"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set",
  "bitflags 2.4.1",
- "block",
+ "cfg_aliases",
  "core-graphics-types",
- "d3d12",
  "glow",
  "glutin_wgl_sys",
  "gpu-alloc",
@@ -2032,7 +1989,6 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "profiling",
- "range-alloc",
  "raw-window-handle",
  "renderdoc-sys",
  "rustc-hash",
@@ -2046,9 +2002,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5ed5f0edf0de351fe311c53304986315ce866f394a2e6df0c4b3c70774bcdd"
+checksum = "895fcbeb772bfb049eb80b2d6e47f6c9af235284e9703c96fc0218a42ffd5af2"
 dependencies = [
  "bitflags 2.4.1",
  "js-sys",
@@ -2219,5 +2175,5 @@ checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.48",
 ]

--- a/all-is-cubes-wasm/Cargo.toml
+++ b/all-is-cubes-wasm/Cargo.toml
@@ -48,7 +48,7 @@ send_wrapper = "0.6.0"
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.34"
 web-time = { version = "0.2.3" }
-wgpu = { version = "0.18.0", features = ["webgl"] }
+wgpu = { version = "0.19.1", default-features = false, features = ["webgl"] }
 # Feature enabling
 yield-progress = { version = "0.1.5", features = ["log_hiccups"] }
 
@@ -144,3 +144,8 @@ overflow-checks = true
 
 [profile.test]
 overflow-checks = true
+
+[patch.crates-io]
+# Here are some patches we might want to apply for development:
+#
+# wgpu = { git = "https://github.com/gfx-rs/wgpu/", branch = "trunk" }

--- a/all-is-cubes-wasm/Cargo.toml
+++ b/all-is-cubes-wasm/Cargo.toml
@@ -40,20 +40,20 @@ futures-channel = "0.3.28"
 getrandom = { version = "0.2.7", features = ["js"] }
 # Feature enabling for indirect dependency all-is-cubes-content → noise → rand → getrandom
 getrandom_old = { package = "getrandom", version = "0.1.16", features = ["wasm-bindgen"] }
-js-sys = "0.3.64"
+js-sys = "0.3.67"
 log = { version = "0.4.17", default-features = false }
-once_cell = "1.18.0"
+once_cell = "1.19.0"
 rand = { version = "0.8.3", default-features = false, features = ["std", "std_rng"] }
 send_wrapper = "0.6.0"
-wasm-bindgen = "0.2.89"
-wasm-bindgen-futures = "0.4.34"
+wasm-bindgen = "0.2.90"
+wasm-bindgen-futures = "0.4.40"
 web-time = { version = "0.2.3" }
 wgpu = { version = "0.19.1", default-features = false, features = ["webgl"] }
 # Feature enabling
 yield-progress = { version = "0.1.5", features = ["log_hiccups"] }
 
 [dependencies.web-sys]
-version = "0.3.64"
+version = "0.3.67"
 features = [
   "console",
   "AddEventListenerOptions",

--- a/all-is-cubes-wasm/src/init.rs
+++ b/all-is-cubes-wasm/src/init.rs
@@ -117,7 +117,9 @@ async fn start_game_with_dom(
         RendererOption::Wgpu => {
             let wgpu_instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
             let surface = wgpu_instance
-                .create_surface_from_canvas(gui_helpers.canvas_helper().canvas())
+                .create_surface(wgpu::SurfaceTarget::Canvas(
+                    gui_helpers.canvas_helper().canvas(),
+                ))
                 .map_err(|_| "Requesting WebGL context failed")?;
             // TODO: we lost the 'request no MSAA' feature
             let adapter = wgpu_instance

--- a/test-renderers/Cargo.toml
+++ b/test-renderers/Cargo.toml
@@ -65,9 +65,10 @@ glam = { version = "0.24", optional = true, features = ["mint"] }
 image = { workspace = true, features = ["png"] }
 itertools = { workspace = true }
 mint = { version = "0.5.9", optional = true }
-rend3 = { git = "https://github.com/BVE-Reborn/rend3/", rev = "a68c76a2809cf545484d727e32a222400134d085", optional = true }
-rend3-gltf = { git = "https://github.com/BVE-Reborn/rend3/", rev = "a68c76a2809cf545484d727e32a222400134d085", optional = true, default-features = false }
-rend3-routine = { git = "https://github.com/BVE-Reborn/rend3/", rev = "a68c76a2809cf545484d727e32a222400134d085", optional = true }
+# TODO: switch back to rend3 upstream when feasible
+rend3 = { git = "https://github.com/kpreid/rend3/", branch = "wgpu19", optional = true }
+rend3-gltf = { git = "https://github.com/kpreid/rend3/", branch = "wgpu19",  optional = true, default-features = false }
+rend3-routine = { git = "https://github.com/kpreid/rend3/", branch = "wgpu19", optional = true }
 rendiff = { workspace = true }
 send_wrapper = { workspace = true }
 serde = { workspace = true }

--- a/test-renderers/src/lib.rs
+++ b/test-renderers/src/lib.rs
@@ -227,15 +227,14 @@ pub fn initialize_logging() {
     // so we can inspect logs but don't have per-renderer-setup spam
     if false {
         // Note: Something like this log configuration also appears in all-is-cubes-desktop.
-        simplelog::TermLogger::init(
+        simplelog::WriteLogger::init(
             simplelog::LevelFilter::Debug,
             simplelog::ConfigBuilder::new()
                 .add_filter_ignore_str("wgpu") // noisy
                 .add_filter_ignore_str("naga") // noisy
                 .add_filter_ignore_str("winit") // noisy at Trace level only
                 .build(),
-            simplelog::TerminalMode::Stderr,
-            simplelog::ColorChoice::Auto,
+            std::io::stderr(),
         )
         .unwrap();
     }

--- a/tools/xtask/src/xtask.rs
+++ b/tools/xtask/src/xtask.rs
@@ -190,7 +190,10 @@ fn main() -> Result<(), ActionError> {
             // libraries with docs elsewhere.
             if config.scope.includes_main_workspace() {
                 let _t = CaptureTime::new(&mut time_log, "doc");
-                cargo().arg("doc").run()?;
+                // TODO: Temporarily using --no-deps due to a bug in Rust 1.75
+                // <https://github.com/rust-lang/rust/issues/114891>.
+                // Revert the commit that introduced this when Rust 1.76 is released.
+                cargo().arg("doc").arg("--no-deps").run()?;
             }
         }
         XtaskCommand::Fmt => {


### PR DESCRIPTION
This requires some compromises:

* `rend3` is not yet officially updated for 0.19, and due to the `web-sys` unstable WebGPU feature mess we can't have both versions of `wgpu` in our tree. So, I forked and patched it (and sent a PR).
* `simplelog` has a pinned version of `termcolor`. We can disable its colored output for now, but we may wish to replace `simplelog` with a different logging implementation.
* There is a bug in Rust 1.75 that causes `cargo doc` to hang when documenting `wgpu-core`. This will be fixed in the next release, at which point we should revert the usage of nightly for docs in this PR.
