### PR TITLE
Adjust polyfill imports to not give warnings when testing w/o `all-is-cubes/std` feature.

### DIFF
--- a/all-is-cubes/src/block/evaluated.rs
+++ b/all-is-cubes/src/block/evaluated.rs
@@ -6,8 +6,9 @@ use core::{fmt, ops};
 use euclid::Vector3D;
 use ordered_float::NotNan;
 
-#[cfg(not(feature = "std"))]
 /// Acts as polyfill for float methods
+#[cfg(not(feature = "std"))] 
+#[allow(unused_imports)]
 use num_traits::float::FloatCore as _;
 
 use crate::block::{

--- a/all-is-cubes/src/camera.rs
+++ b/all-is-cubes/src/camera.rs
@@ -8,8 +8,9 @@ use itertools::Itertools as _;
 use num_traits::One;
 use ordered_float::NotNan;
 
-#[cfg(not(feature = "std"))]
 /// Acts as polyfill for float methods
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 use num_traits::float::Float as _;
 
 use crate::chunking::OctantMask;
@@ -672,5 +673,3 @@ fn projected_range(
         .into_option()
         .unwrap()
 }
-
-

--- a/all-is-cubes/src/character.rs
+++ b/all-is-cubes/src/character.rs
@@ -8,8 +8,9 @@ use hashbrown::HashSet as HbHashSet;
 use manyfmt::Fmt;
 use ordered_float::NotNan;
 
-#[cfg(not(feature = "std"))]
 /// Acts as polyfill for float methods
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 use num_traits::float::Float as _;
 
 use crate::behavior::{self, Behavior, BehaviorSet, BehaviorSetTransaction};
@@ -17,6 +18,7 @@ use crate::camera::ViewTransform;
 use crate::inv::{self, Inventory, InventoryTransaction, Slot, Tool};
 use crate::listen::{Listen, Listener, Notifier};
 #[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 use crate::math::Euclid as _;
 use crate::math::{Aab, Cube, Face6, Face7, FreeCoordinate, FreePoint, FreeVector, Rgb, VectorOps};
 use crate::physics::{Body, BodyStepInfo, BodyTransaction, Contact, Velocity};

--- a/all-is-cubes/src/chunking.rs
+++ b/all-is-cubes/src/chunking.rs
@@ -12,11 +12,13 @@ use std::sync::Mutex;
 
 use euclid::{vec3, Point3D, Vector3D};
 
-#[cfg(not(feature = "std"))]
 /// Acts as polyfill for float methods
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 use num_traits::float::FloatCore as _;
 
 #[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 use crate::math::Euclid as _;
 use crate::math::{
     Cube, FreeCoordinate, FreePoint, FreeVector, GridAab, GridCoordinate, GridPoint, VectorOps,

--- a/all-is-cubes/src/inv/icons.rs
+++ b/all-is-cubes/src/inv/icons.rs
@@ -6,8 +6,9 @@ use embedded_graphics::primitives::{Circle, Line, PrimitiveStyleBuilder};
 use euclid::vec3;
 use exhaust::Exhaust;
 
-#[cfg(not(feature = "std"))]
 /// Acts as polyfill for float methods
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 use num_traits::float::FloatCore as _;
 
 use crate::block::{Block, Resolution::*, AIR, AIR_EVALUATED};

--- a/all-is-cubes/src/linking.rs
+++ b/all-is-cubes/src/linking.rs
@@ -479,8 +479,6 @@ mod tests {
     use crate::math::GridAab;
     use crate::transaction::{self, Transaction as _};
     use crate::util::assert_send_sync;
-    use alloc::string::ToString;
-    use std::error::Error;
 
     #[derive(Exhaust, Clone, Debug, Eq, Hash, PartialEq)]
     enum Key {
@@ -564,6 +562,9 @@ mod tests {
     #[test]
     #[cfg(feature = "std")] // Error::source only exists on std
     fn gen_error_message() {
+        use alloc::string::ToString;
+        use std::error::Error;
+
         let set_cube_error = SetCubeError::OutOfBounds {
             modification: GridAab::for_block(R1),
             space_bounds: GridAab::for_block(R4),

--- a/all-is-cubes/src/math.rs
+++ b/all-is-cubes/src/math.rs
@@ -4,8 +4,9 @@ use euclid::Vector3D;
 use num_traits::identities::Zero;
 pub use ordered_float::{FloatIsNan, NotNan};
 
-#[cfg(not(feature = "std"))]
 /// Acts as polyfill for float methods
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 use num_traits::float::FloatCore as _;
 
 use crate::util::ConciseDebug;

--- a/all-is-cubes/src/math/aab.rs
+++ b/all-is-cubes/src/math/aab.rs
@@ -4,8 +4,9 @@ use core::iter::FusedIterator;
 
 use euclid::{Point3D, Vector3D};
 
-#[cfg(not(feature = "std"))]
 /// Acts as polyfill for float methods
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 use num_traits::float::FloatCore as _;
 
 use crate::math::{

--- a/all-is-cubes/src/math/color.rs
+++ b/all-is-cubes/src/math/color.rs
@@ -7,8 +7,9 @@ use core::ops::{Add, AddAssign, Mul, Sub};
 use euclid::{vec3, Vector3D};
 use ordered_float::{FloatIsNan, NotNan};
 
-#[cfg(not(feature = "std"))]
 /// Acts as polyfill for float methods
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 use num_traits::float::Float as _;
 
 use crate::math::VectorOps as _;

--- a/all-is-cubes/src/math/cube.rs
+++ b/all-is-cubes/src/math/cube.rs
@@ -1,7 +1,8 @@
 use core::fmt;
 
-#[cfg(not(feature = "std"))]
 /// Acts as polyfill for float methods
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 use num_traits::float::FloatCore as _;
 
 use crate::math::{

--- a/all-is-cubes/src/math/face.rs
+++ b/all-is-cubes/src/math/face.rs
@@ -6,8 +6,9 @@ use core::ops::{Index, IndexMut};
 
 use euclid::Vector3D;
 
-#[cfg(not(feature = "std"))]
 /// Acts as polyfill for float methods
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 use num_traits::float::FloatCore as _;
 
 use crate::math::{

--- a/all-is-cubes/src/math/matrix.rs
+++ b/all-is-cubes/src/math/matrix.rs
@@ -7,8 +7,9 @@ use core::ops;
 use euclid::Vector3D;
 use num_traits::One;
 
-#[cfg(not(feature = "std"))]
 /// Acts as polyfill for float methods
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 use num_traits::float::FloatCore as _;
 
 use crate::math::{

--- a/all-is-cubes/src/physics/body.rs
+++ b/all-is-cubes/src/physics/body.rs
@@ -6,8 +6,9 @@ use euclid::Vector3D;
 use manyfmt::Fmt;
 use ordered_float::NotNan;
 
-#[cfg(not(feature = "std"))]
 /// Acts as polyfill for float methods
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 use num_traits::float::Float as _;
 
 use super::collision::{
@@ -16,6 +17,7 @@ use super::collision::{
 use crate::block::{BlockCollision, Resolution};
 use crate::fluff::Fluff;
 #[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 use crate::math::Euclid as _;
 use crate::math::{Aab, Face7, FreeCoordinate, FreePoint, FreeVector, Geometry as _, VectorOps};
 use crate::physics::{StopAt, Velocity, POSITION_EPSILON};

--- a/all-is-cubes/src/physics/collision.rs
+++ b/all-is-cubes/src/physics/collision.rs
@@ -7,8 +7,9 @@ use core::fmt;
 use euclid::Vector3D;
 use hashbrown::HashSet as HbHashSet;
 
-#[cfg(not(feature = "std"))]
 /// Acts as polyfill for float methods
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 use num_traits::float::FloatCore as _;
 
 use super::POSITION_EPSILON;

--- a/all-is-cubes/src/raycast.rs
+++ b/all-is-cubes/src/raycast.rs
@@ -9,11 +9,13 @@ use core::f64::consts::TAU;
 
 use euclid::Vector3D;
 
-#[cfg(not(feature = "std"))]
 /// Acts as polyfill for float methods
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 use num_traits::float::Float as _;
 
 #[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 use crate::math::Euclid as _;
 use crate::math::{
     Axis, Cube, CubeFace, Face7, FreeCoordinate, FreePoint, FreeVector, Geometry, GridAab,

--- a/all-is-cubes/src/raytracer.rs
+++ b/all-is-cubes/src/raytracer.rs
@@ -15,8 +15,9 @@ use core::fmt;
 
 use euclid::{vec3, Vector2D, Vector3D};
 use manyfmt::Fmt;
-#[cfg(not(feature = "std"))]
 /// Acts as polyfill for float methods
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 use num_traits::float::Float as _;
 use ordered_float::NotNan;
 
@@ -27,6 +28,7 @@ use crate::block::{Evoxels, Resolution, AIR};
 use crate::camera::NdcPoint2;
 use crate::camera::{Camera, GraphicsOptions, TransparencyOption};
 #[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 use crate::math::Euclid as _;
 use crate::math::{
     smoothstep, Cube, Face6, Face7, FreeCoordinate, FreePoint, FreeVector, GridAab, GridMatrix,

--- a/all-is-cubes/src/space/light/data.rs
+++ b/all-is-cubes/src/space/light/data.rs
@@ -4,8 +4,9 @@ use core::fmt;
 
 use euclid::default::Vector3D;
 
-#[cfg(not(feature = "std"))]
 /// Acts as polyfill for float methods
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
 use num_traits::float::Float as _;
 
 use crate::math::{NotNan, Rgb};

--- a/all-is-cubes/src/util.rs
+++ b/all-is-cubes/src/util.rs
@@ -227,13 +227,15 @@ pub fn assert_conditional_send_sync<T>() {}
 
 #[cfg(test)]
 mod tests {
+    #[allow(unused)]
     use super::*;
-    use std::error::Error;
-    use std::fmt;
 
     #[test]
     #[cfg(feature = "std")]
     fn error_chain() {
+        use std::error::Error;
+        use std::fmt;
+
         #[derive(Debug)]
         struct TestError1;
         impl Error for TestError1 {}


### PR DESCRIPTION
It seems that when compiling the lib as a dependency of tests (that is, with `cfg(test)` *not* set), std is linked anyway and so the trait imports count as unused because they're shadowed by std inherent methods. This doesn't quite make sense and is worth further investigation, but `allow(unused_imports)` will suppress the warnings that I can't otherwise deal with.