### PR TITLE
Precompute light propagation data at build time instead of in Space initialization.

### DIFF
--- a/all-is-cubes/src/space/light/chart_schema.rs
+++ b/all-is-cubes/src/space/light/chart_schema.rs
@@ -1,14 +1,12 @@
-use crate::raycast::Ray;
+use euclid::Point3D;
+
+use all_is_cubes_base::math::{Cube, CubeFace};
 
 #[path = "chart_schema_shared.rs"]
 mod chart_schema_shared;
-pub(crate) use chart_schema_shared::OneRay;
+pub(crate) use chart_schema_shared::*;
 
 impl OneRay {
-    pub fn ray(&self) -> Ray {
-        Ray::new(self.origin, self.direction)
-    }
-
     pub fn face_cosines(&self) -> crate::math::FaceMap<f32> {
         let [nx, ny, nz, px, py, pz] = self.face_cosines;
         crate::math::FaceMap {
@@ -18,6 +16,15 @@ impl OneRay {
             px,
             py,
             pz,
+        }
+    }
+}
+
+impl Step {
+    pub fn relative_cube_face(self) -> CubeFace {
+        CubeFace {
+            cube: Cube::from(Point3D::from(self.relative_cube).to_i32()),
+            face: self.face.into(),
         }
     }
 }

--- a/all-is-cubes/src/space/light/chart_schema_shared.rs
+++ b/all-is-cubes/src/space/light/chart_schema_shared.rs
@@ -8,19 +8,104 @@
 //! In the future, this may be handled by using number types wrapped to be explicitly
 //! target endianness.
 
+use all_is_cubes_base::math::Face7;
+
 // conditionally defined to be equal to f32 except in the build script
 use super::TargetEndian;
 
+/// Information about a single one of the bundle of light rays that we follow
+/// from a struck block towards light sources.
 #[derive(Clone, Copy, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 pub(crate) struct OneRay {
-    // This can't be a `Ray` because `FaceMap` is not `repr(C)`
-    pub origin: [TargetEndian<f64>; 3],
-    pub direction: [TargetEndian<f64>; 3],
-    // This can't be a `FaceMap` because `FaceMap` is not `repr(C)`
+    /// Ray whose origin is within the [0,0,0]..[1,1,1] cube and direction
+    /// is a unit vector in the direction of this light ray.
+    pub ray: Ray,
+    /// `FaceMap` data which stores the cosine between each face normal and this ray.
     pub face_cosines: [TargetEndian<f32>; 6],
 }
 
-// Note: All of the methods are either only used for reading or only used for writing,
+/// The pre-computed sequence of cubes which is traversed by a [`OneRay`].
+/// This format is used only while computing them.
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+#[repr(C)]
+pub(crate) struct Steps {
+    pub info: OneRay,
+    pub relative_cube_sequence: ::alloc::vec::Vec<Step>,
+}
+
+/// The pre-computed sequence of cubes which is traversed by a [`OneRay`].
+/// This format is used in the static pre-computed data.
+#[derive(Clone, Copy, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(C)]
+pub(crate) struct IndirectSteps {
+    pub info: OneRay,
+    /// Sequence of steps to take, specified by an inclusive-exclusive range of a slice of
+    /// separately stored [`Step`]s.
+    pub relative_cube_sequence: [usize; 2],
+}
+
+#[derive(Clone, Copy, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(C)]
+pub(crate) struct Step {
+    /// Cube we just hit, relative to the origin of rays
+    /// (the block we're computing light for).
+    pub relative_cube: [TargetEndian<i8>; 3],
+
+    /// Distance from ray origin that has been traversed so far to strike this cube,
+    /// rounded up.
+    pub distance: u8,
+
+    /// Face struck.
+    pub face: Face7Safe,
+}
+
+#[derive(Clone, Copy, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(C)]
+pub(crate) struct Ray {
+    pub origin: [TargetEndian<f64>; 3],
+    pub direction: [TargetEndian<f64>; 3],
+}
+
+impl From<Ray> for all_is_cubes_base::raycast::Ray {
+    fn from(value: Ray) -> Self {
+        Self::new(value.origin.map(f64::from), value.direction.map(f64::from))
+    }
+}
+
+/// [`Face6`] but without an enum's validity invariant.
+/// Panics on unsuccessful conversion.
+#[derive(Clone, Copy, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(transparent)]
+pub(crate) struct Face7Safe(u8);
+impl From<Face7Safe> for Face7 {
+    fn from(value: Face7Safe) -> Self {
+        match value.0 {
+            0 => Face7::Within,
+            1 => Face7::NX,
+            2 => Face7::NY,
+            3 => Face7::NZ,
+            4 => Face7::PX,
+            5 => Face7::PY,
+            6 => Face7::PZ,
+            _ => {
+                if cfg!(debug_assertions) {
+                    panic!("invalid {value:?}");
+                } else {
+                    // avoid generating a panic branch
+                    Face7::Within
+                }
+            }
+        }
+    }
+}
+impl From<Face7> for Face7Safe {
+    fn from(value: Face7) -> Self {
+        Self(value as u8)
+    }
+}
+
+// Note: Most of the methods are either only used for reading or only used for writing,
 // so they're defined in the respective crates to reduce complications like what they depend on,
 // how `TargetEndian` is defined, and dead code warnings.


### PR DESCRIPTION
Instead of making a chart for the exact right size, we make the biggest one we can, then do a distance check while iterating. This avoids redundant run-time work and, in particular, should make the tests we run under Miri that happen to allocate `Space`s much faster.

Size of the data is a concern; it's currently 645 KB. In the future, I plan to replace this data structure with one which combines nearly-parallel rays that traverse the same cubes, until they diverge, instead of redundantly storing and iterating over each ray's sequence of cubes. That will allow more rays for the same data and compute costs.

One unused possibility for further compression is storing *only* the face/step directions instead of both the faces and the cube coordinates.

Part of #490