### PR TITLE
Use a new `wgpu::Adapter` for each `wgpu::Device`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,9 @@
         
     - The macros `rgb_const!`, `rgba_const!`, and `notnan!` have been moved to the `math` module.
 
+- `all-is-cubes-gpu` library:
+    - `in_wgpu::headless::Builder::from_adapter()` requires `wgpu::Adapter` instead of `Arc<wgpu::Adapter>`.
+
 - `all-is-cubes-mesh` library:
     - The return type of `GetBlockMesh::get_block_mesh()` has changed to `Option<&BlockMesh>`.
       `None` is to be returned when the implementor intends to request that the block be _omitted_ from a produced `SpaceMesh` (such as when it is being rendered separately) rather than the mesh merely being empty (invisible).

--- a/all-is-cubes-gpu/tests/shaders/harness.rs
+++ b/all-is-cubes-gpu/tests/shaders/harness.rs
@@ -1,6 +1,3 @@
-use std::io::Write as _;
-use std::sync::Arc;
-
 use half::f16;
 
 use all_is_cubes::camera;
@@ -12,33 +9,16 @@ use all_is_cubes_gpu::in_wgpu::shader_testing;
 ///
 /// We don't share the [`wgpu::Device`] because it can enter failure states,
 /// but we can use just one [`wgpu::Adapter`] to create all of them.
-pub(crate) async fn adapter() -> Arc<wgpu::Adapter> {
-    static CELL: tokio::sync::OnceCell<Arc<wgpu::Adapter>> = tokio::sync::OnceCell::const_new();
-
-    CELL.get_or_init(|| async {
-        let (_instance, adapter) =
-            init::create_instance_and_adapter_for_test(|msg| eprintln!("{msg}")).await;
-        match adapter {
-            Some(adapter) => Arc::new(adapter),
-            None => {
-                // don't use eprintln! so test harness does not capture it
-                let _ = writeln!(
-                    std::io::stderr(),
-                    "Skipping rendering tests due to lack of wgpu::Adapter."
-                );
-                // Exit the process to skip redundant reports and make it clear that the
-                // tests aren't just passing
-                std::process::exit(0);
-            }
-        }
-    })
-    .await
-    .clone()
+pub(crate) async fn instance() -> &'static wgpu::Instance {
+    static CELL: tokio::sync::OnceCell<wgpu::Instance> = tokio::sync::OnceCell::const_new();
+    CELL.get_or_init(init::create_instance_for_test_or_exit)
+        .await
 }
 
 /// TODO: image probably isn't the best output format, just what I prototyped with
 pub(crate) async fn run_shader_test(test_wgsl: &str) -> image::Rgba32FImage {
-    let adapter = adapter().await;
+    let instance = instance().await;
+    let adapter = init::create_adapter_for_test(instance).await;
 
     // 32 is the minimum viewport width that will satisfy copy alignment
     let output_viewport = camera::Viewport::with_scale(1.0, [32, 32]);

--- a/all-is-cubes-wasm/tests/browser/render.rs
+++ b/all-is-cubes-wasm/tests/browser/render.rs
@@ -4,7 +4,6 @@
 //! TODO: Consider expanding this out to running all of test-renderers. This will need more work.
 
 use core::time::Duration;
-use std::sync::Arc;
 
 use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -18,8 +17,8 @@ use all_is_cubes_wasm::AdaptedInstant as Instant;
 
 #[wasm_bindgen_test]
 async fn renderer_test() {
-    let (_instance, adapter) =
-        init::create_instance_and_adapter_for_test(|msg| eprintln!("{msg}")).await;
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
+    let adapter = init::try_create_adapter_for_test(&instance, |msg| eprintln!("{msg}")).await;
 
     // Skip this test if no adapter available
     let Some(adapter) = adapter else { return };
@@ -43,11 +42,10 @@ async fn renderer_test() {
     );
     let world_space = cameras.world_space().snapshot().unwrap();
 
-    let mut renderer =
-        all_is_cubes_gpu::in_wgpu::headless::Builder::from_adapter(Arc::new(adapter))
-            .await
-            .unwrap()
-            .build(cameras.clone());
+    let mut renderer = all_is_cubes_gpu::in_wgpu::headless::Builder::from_adapter(adapter)
+        .await
+        .unwrap()
+        .build(cameras.clone());
     renderer.update(None).await.unwrap();
     let image = renderer.draw("").await.unwrap();
 


### PR DESCRIPTION
This obeys the rules for `requestDevice()` in the WebGPU specification, which `wgpu` does not yet enforce but may in a future version.

Only tests and `headless::Builder` are affected.