### PR TITLE
Replace `PreconditionFailed` with types for each transaction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,8 @@
 
     - `op::Operation::Paint` has been removed. Use `Operation::Neighbors` and `Operation::DestroyTo` to get the same effect.
 
+    - `transaction::PreconditionFailed` no longer exists. It has been replaced with error types specific to each transaction type.
+
 ## 0.7.1 (2024-01-27)
 
 - `all-is-cubes` library:

--- a/all-is-cubes/src/physics/body.rs
+++ b/all-is-cubes/src/physics/body.rs
@@ -704,9 +704,9 @@ impl Transaction for BodyTransaction {
     type Target = Body;
     type CommitCheck = ();
     type Output = transaction::NoOutput;
-    type Mismatch = transaction::PreconditionFailed;
+    type Mismatch = BodyMismatch;
 
-    fn check(&self, _body: &Body) -> Result<Self::CommitCheck, transaction::PreconditionFailed> {
+    fn check(&self, _body: &Body) -> Result<Self::CommitCheck, Self::Mismatch> {
         // No conflicts currently possible.
         Ok(())
     }
@@ -733,6 +733,20 @@ impl transaction::Merge for BodyTransaction {
     fn commit_merge(&mut self, other: Self, (): Self::MergeCheck) {
         let Self { delta_yaw } = self;
         *delta_yaw += other.delta_yaw;
+    }
+}
+
+/// Transaction precondition error type for a [`BodyTransaction`].
+#[derive(Clone, Debug, Eq, PartialEq, displaydoc::Display)]
+#[non_exhaustive]
+pub enum BodyMismatch {}
+
+crate::util::cfg_should_impl_error! {
+    impl std::error::Error for BodyMismatch {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            match *self {
+            }
+        }
     }
 }
 

--- a/all-is-cubes/src/transaction.rs
+++ b/all-is-cubes/src/transaction.rs
@@ -310,24 +310,6 @@ where
     }
 }
 
-/// Error type returned by [`Transaction::check`].
-///
-/// Note: This type is designed to be cheap to construct, as it is expected that game
-/// mechanics _may_ result in transactions repeatedly failing. Hence, it does not contain
-/// full details on the failure.
-#[derive(Clone, Debug, PartialEq, displaydoc::Display)]
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[displaydoc("Transaction precondition not met: {location}: {problem}")]
-pub struct PreconditionFailed {
-    // TODO: Figure out how to have at least a little dynamic information. `Option<[i32; 3]>` ???
-    pub(crate) location: &'static str,
-    pub(crate) problem: &'static str,
-}
-
-crate::util::cfg_should_impl_error! {
-    impl std::error::Error for PreconditionFailed {}
-}
-
 /// Type of “unexpected errors” from [`Transaction::commit()`].
 //---
 // Design note: `CommitError` doesn't need to be cheap because it should never happen

--- a/all-is-cubes/src/universe.rs
+++ b/all-is-cubes/src/universe.rs
@@ -773,11 +773,24 @@ pub enum InsertErrorKind {
     /// An object already exists with the proposed name.
     AlreadyExists,
     /// The proposed name may not be used.
+    ///
+    /// In particular, a [`Name::Anonym`] may not be inserted explicitly.
     InvalidName,
     /// The provided [`Handle`] does not have a value.
     Gone,
+    /// The provided [`Handle`]’s value is being mutated and cannot
+    /// be checked.
+    InUse,
     /// The provided [`Handle`] was already inserted into some universe.
     AlreadyInserted,
+    #[doc(hidden)] // should be unreachable
+    /// The provided [`Handle`] is being used in the deserialization process
+    /// and cannot be inserted otherwise.
+    Deserializing,
+    #[doc(hidden)]
+    /// The provided [`Handle`] experienced an error during a previous operation and
+    /// cannot be used.
+    Poisoned,
 }
 
 crate::util::cfg_should_impl_error! {
@@ -795,7 +808,18 @@ impl fmt::Display for InsertError {
                 write!(f, "the name {name} may not be used in an insert operation")
             }
             InsertErrorKind::Gone => write!(f, "the Handle {name} was already dead"),
+            InsertErrorKind::InUse => write!(
+                f,
+                "the object {name} is being mutated during this insertion attempt"
+            ),
             InsertErrorKind::AlreadyInserted => write!(f, "the object {name} is already inserted"),
+            InsertErrorKind::Deserializing => write!(
+                f,
+                "the object {name} is already in a universe being deserialized"
+            ),
+            InsertErrorKind::Poisoned => {
+                write!(f, "the object is invalid due to a previous failure")
+            }
         }
     }
 }


### PR DESCRIPTION
This allows the transactions to give much more specific information about precondition failures, while still not allocating anything.