### PR TITLE
Deps: Update `wgpu` from 0.19.2 to 22.1.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
  "tokio",
  "trycmd",
  "unicode-width",
- "wgpu",
+ "wgpu 22.1.0",
  "winit",
  "yield-progress",
 ]
@@ -208,7 +208,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "web-time 1.1.0",
- "wgpu",
+ "wgpu 22.1.0",
 ]
 
 [[package]]
@@ -508,6 +508,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a"
 dependencies = [
  "libloading 0.7.4",
+]
+
+[[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading 0.8.4",
 ]
 
 [[package]]
@@ -893,7 +902,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f"
+dependencies = [
+ "bit-vec 0.7.0",
 ]
 
 [[package]]
@@ -901,6 +919,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
 
 [[package]]
 name = "bitflags"
@@ -1657,6 +1681,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "d3d12"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdbd1f579714e3c809ebd822c81ef148b1ceaeb3d535352afc73fd0c4c6a0017"
+dependencies = [
+ "bitflags 2.6.0",
+ "libloading 0.8.4",
+ "winapi",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,9 +1814,9 @@ dependencies = [
 
 [[package]]
 name = "document-features"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5282ad69563b5fc40319526ba27e0e7363d552a896f0297d54f767717f9b95"
+checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
 dependencies = [
  "litrs",
 ]
@@ -2497,6 +2532,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "glutin_wgl_sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a4e1951bbd9434a81aa496fe59ccc2235af3820d27b85f9314e279609211e2c"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
 name = "gpu-alloc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2529,13 +2573,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpu-allocator"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd4240fc91d3433d5e5b0fc5b67672d771850dc19bbee03c1381e19322803d7"
+dependencies = [
+ "log",
+ "presser",
+ "thiserror",
+ "winapi",
+ "windows 0.52.0",
+]
+
+[[package]]
 name = "gpu-descriptor"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
 dependencies = [
  "bitflags 2.6.0",
- "gpu-descriptor-types",
+ "gpu-descriptor-types 0.1.2",
+ "hashbrown",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c08c1f623a8d0b722b8b99f821eb0ba672a1618f0d3b16ddbee1cedd2dd8557"
+dependencies = [
+ "bitflags 2.6.0",
+ "gpu-descriptor-types 0.2.0",
  "hashbrown",
 ]
 
@@ -2544,6 +2612,15 @@ name = "gpu-descriptor-types"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bf0b36e6f090b7e1d8a4b49c0cb81c1f8376f72198c65dd3ad9ff3556b8b78c"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -3292,6 +3369,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "metal"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+dependencies = [
+ "bitflags 2.6.0",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
 name = "micromath"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3379,13 +3471,34 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50e3524642f53d9af419ab5e8dd29d3ba155708267667c2f3f06c88c9e130843"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "bitflags 2.6.0",
  "codespan-reporting",
  "hexf-parse",
  "indexmap",
  "log",
  "num-traits",
+ "rustc-hash",
+ "spirv",
+ "termcolor",
+ "thiserror",
+ "unicode-xid",
+]
+
+[[package]]
+name = "naga"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09eeccb9b50f4f7839b214aa3e08be467159506a986c18e0702170ccf720a453"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.6.0",
+ "bitflags 2.6.0",
+ "cfg_aliases 0.1.1",
+ "codespan-reporting",
+ "hexf-parse",
+ "indexmap",
+ "log",
  "rustc-hash",
  "spirv",
  "termcolor",
@@ -5023,7 +5136,7 @@ dependencies = [
  "smallvec",
  "smartstring",
  "thiserror",
- "wgpu",
+ "wgpu 0.19.4",
  "wgpu-profiler",
 ]
 
@@ -5060,7 +5173,7 @@ dependencies = [
  "flume",
  "glam 0.24.2",
  "log",
- "naga",
+ "naga 0.19.2",
  "ordered-float",
  "parking_lot",
  "profiling",
@@ -5068,7 +5181,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
- "wgpu",
+ "wgpu 0.19.4",
  "wgpu-profiler",
 ]
 
@@ -5085,7 +5198,7 @@ dependencies = [
  "list-any",
  "once_cell",
  "thiserror",
- "wgpu-types",
+ "wgpu-types 0.19.2",
 ]
 
 [[package]]
@@ -5842,23 +5955,23 @@ dependencies = [
  "time",
  "tinytemplate",
  "tokio",
- "wgpu",
+ "wgpu 22.1.0",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6410,7 +6523,7 @@ dependencies = [
  "cfg_aliases 0.1.1",
  "js-sys",
  "log",
- "naga",
+ "naga 0.19.2",
  "parking_lot",
  "profiling",
  "raw-window-handle 0.6.2",
@@ -6419,9 +6532,33 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "wgpu-core",
- "wgpu-hal",
- "wgpu-types",
+ "wgpu-core 0.19.4",
+ "wgpu-hal 0.19.5",
+ "wgpu-types 0.19.2",
+]
+
+[[package]]
+name = "wgpu"
+version = "22.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d1c4ba43f80542cf63a0a6ed3134629ae73e8ab51e4b765a67f3aa062eb433"
+dependencies = [
+ "arrayvec",
+ "cfg_aliases 0.1.1",
+ "document-features",
+ "js-sys",
+ "log",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle 0.6.2",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core 22.0.0",
+ "wgpu-hal 22.0.0",
+ "wgpu-types 22.0.0",
 ]
 
 [[package]]
@@ -6431,13 +6568,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b94525fc99ba9e5c9a9e24764f2bc29bad0911a7446c12f446a8277369bf3a"
 dependencies = [
  "arrayvec",
- "bit-vec",
+ "bit-vec 0.6.3",
  "bitflags 2.6.0",
  "cfg_aliases 0.1.1",
  "codespan-reporting",
  "indexmap",
  "log",
- "naga",
+ "naga 0.19.2",
  "once_cell",
  "parking_lot",
  "profiling",
@@ -6446,8 +6583,33 @@ dependencies = [
  "smallvec",
  "thiserror",
  "web-sys",
- "wgpu-hal",
- "wgpu-types",
+ "wgpu-hal 0.19.5",
+ "wgpu-types 0.19.2",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f191908a21968991463fcf3b42cb6c9648c0fb7fa301b8fc733bc21a9ed9bd"
+dependencies = [
+ "arrayvec",
+ "bit-vec 0.7.0",
+ "bitflags 2.6.0",
+ "cfg_aliases 0.1.1",
+ "document-features",
+ "indexmap",
+ "log",
+ "naga 22.0.0",
+ "once_cell",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle 0.6.2",
+ "rustc-hash",
+ "smallvec",
+ "thiserror",
+ "wgpu-hal 22.0.0",
+ "wgpu-types 22.0.0",
 ]
 
 [[package]]
@@ -6458,26 +6620,26 @@ checksum = "bfabcfc55fd86611a855816326b2d54c3b2fd7972c27ce414291562650552703"
 dependencies = [
  "android_system_properties",
  "arrayvec",
- "ash",
- "bit-set",
+ "ash 0.37.3+1.3.251",
+ "bit-set 0.5.3",
  "bitflags 2.6.0",
  "block",
  "cfg_aliases 0.1.1",
  "core-graphics-types",
- "d3d12",
+ "d3d12 0.19.0",
  "glow",
- "glutin_wgl_sys",
+ "glutin_wgl_sys 0.5.0",
  "gpu-alloc",
- "gpu-allocator",
- "gpu-descriptor",
+ "gpu-allocator 0.25.0",
+ "gpu-descriptor 0.2.4",
  "hassle-rs",
  "js-sys",
  "khronos-egl",
  "libc",
  "libloading 0.8.4",
  "log",
- "metal",
- "naga",
+ "metal 0.27.0",
+ "naga 0.19.2",
  "ndk-sys 0.5.0+25.2.9519653",
  "objc",
  "once_cell",
@@ -6491,7 +6653,52 @@ dependencies = [
  "thiserror",
  "wasm-bindgen",
  "web-sys",
- "wgpu-types",
+ "wgpu-types 0.19.2",
+ "winapi",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6bbf4b4de8b2a83c0401d9e5ae0080a2792055f25859a02bf9be97952bbed4f"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash 0.38.0+1.3.281",
+ "bit-set 0.6.0",
+ "bitflags 2.6.0",
+ "block",
+ "cfg_aliases 0.1.1",
+ "core-graphics-types",
+ "d3d12 22.0.0",
+ "glow",
+ "glutin_wgl_sys 0.6.0",
+ "gpu-alloc",
+ "gpu-allocator 0.26.0",
+ "gpu-descriptor 0.3.0",
+ "hassle-rs",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading 0.8.4",
+ "log",
+ "metal 0.29.0",
+ "naga 22.0.0",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "objc",
+ "once_cell",
+ "parking_lot",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle 0.6.2",
+ "renderdoc-sys",
+ "rustc-hash",
+ "smallvec",
+ "thiserror",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu-types 22.0.0",
  "winapi",
 ]
 
@@ -6503,7 +6710,7 @@ checksum = "198b96a1940b527c6e21ab829b3630eb4e8ffb602fd12839d8c5e088c8e06192"
 dependencies = [
  "parking_lot",
  "thiserror",
- "wgpu",
+ "wgpu 0.19.4",
 ]
 
 [[package]]
@@ -6511,6 +6718,17 @@ name = "wgpu-types"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b671ff9fb03f78b46ff176494ee1ebe7d603393f42664be55b64dc8d53969805"
+dependencies = [
+ "bitflags 2.6.0",
+ "js-sys",
+ "web-sys",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9d91f0e2c4b51434dfa6db77846f2793149d8e73f800fa2e41f52b8eac3c5d"
 dependencies = [
  "bitflags 2.6.0",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ arbitrary = { version = "1.3.2", features = ["derive"] }
 arrayvec = { version = "0.7.4", default-features = false }
 async_fn_traits = "0.1.1"
 base64 = { version = "0.22.1", default-features = false }
-bitflags = { version = "2.4", default-features = false }
+bitflags = { version = "2.6.0", default-features = false }
 bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 # Note that this excludes the "derive" feature but some crates need it.
 bytemuck = { version = "1.13.1", default-features = false }
@@ -129,7 +129,7 @@ snapbox = "0.6.10" # keep in sync with `trycmd`
 strum = { version = "0.26.1", default-features = false, features = ["derive"] }
 sync_wrapper = { version = "1.0.0", default-features = false }
 tempfile = "3.3.0"
-thiserror = "1.0.56"
+thiserror = "1.0.62"
 time = { version = "0.3.36", default-features = false }
 # Tokio is used for async test-running and for certain binaries.
 # The library crates do not require Tokio.
@@ -137,9 +137,9 @@ tokio = { version = "1.28.0", default-features = false }
 trycmd = "0.15.4" # keep in sync with `snapbox`
 unicode-segmentation = { version = "1.10.1", default-features = false }
 unicode-width = { version = "0.1.9", default-features = false }
-wasm-bindgen-futures = "0.4.40"
+wasm-bindgen-futures = "0.4.42"
 web-time = "1.0.0"
-wgpu = { version = "0.19.3", default-features = false, features = ["wgsl"] }
+wgpu = { version = "22.1.0", default-features = false, features = ["wgsl"] }
 yield-progress = { version = "0.1.6", default-features = false }
 
 # Note: Lints are also necessarily redefined in the workspaces other than this one.

--- a/all-is-cubes-gpu/Cargo.toml
+++ b/all-is-cubes-gpu/Cargo.toml
@@ -77,7 +77,7 @@ resource = "0.5.0"
 send_wrapper = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 # For initializing tests on web. (This is not a dev-dependency because some of said tests are not in this package.)
-web-sys = { version = "0.3.67", features = ["OffscreenCanvas"] }
+web-sys = { version = "0.3.69", features = ["OffscreenCanvas"] }
 web-time = { workspace = true }
 wgpu = { workspace = true, optional = true }
 

--- a/all-is-cubes-gpu/src/in_wgpu.rs
+++ b/all-is-cubes-gpu/src/in_wgpu.rs
@@ -339,12 +339,13 @@ impl<I: time::Instant> EverythingRenderer<I> {
     /// A device descriptor suitable for the expectations of [`EverythingRenderer`].
     pub fn device_descriptor(available_limits: wgpu::Limits) -> wgpu::DeviceDescriptor<'static> {
         wgpu::DeviceDescriptor {
+            label: None,
             required_features: wgpu::Features::empty(),
             required_limits: wgpu::Limits {
                 max_inter_stage_shader_components: 32, // number used by blocks-and-lines shader
                 ..wgpu::Limits::downlevel_webgl2_defaults().using_resolution(available_limits)
             },
-            label: None,
+            memory_hints: wgpu::MemoryHints::default(), // TODO: consider setting
         }
     }
 

--- a/all-is-cubes-gpu/src/in_wgpu/bloom.rs
+++ b/all-is-cubes-gpu/src/in_wgpu/bloom.rs
@@ -63,11 +63,13 @@ impl BloomPipelines {
             vertex: wgpu::VertexState {
                 module: shaders.bloom.get(),
                 entry_point: "bloom_vertex",
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
                 buffers: &[],
             },
             fragment: Some(wgpu::FragmentState {
                 module: shaders.bloom.get(),
                 entry_point: "bloom_downsample_fragment",
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: linear_scene_texture_format,
                     blend: None,
@@ -79,6 +81,7 @@ impl BloomPipelines {
             // default = off. No need for multisampling since we are not drawing triangles here.
             multisample: wgpu::MultisampleState::default(),
             multiview: None,
+            cache: None,
         });
         let upsample_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: Some("BloomPipelines::upsample_pipeline"),
@@ -86,11 +89,13 @@ impl BloomPipelines {
             vertex: wgpu::VertexState {
                 module: shaders.bloom.get(),
                 entry_point: "bloom_vertex",
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
                 buffers: &[],
             },
             fragment: Some(wgpu::FragmentState {
                 module: shaders.bloom.get(),
                 entry_point: "bloom_upsample_fragment",
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: linear_scene_texture_format,
                     blend: None,
@@ -102,6 +107,7 @@ impl BloomPipelines {
             // default = off. No need for multisampling since we are not drawing triangles here.
             multisample: wgpu::MultisampleState::default(),
             multiview: None,
+            cache: None,
         });
 
         #[cfg_attr(target_family = "wasm", allow(clippy::arc_with_non_send_sync))]

--- a/all-is-cubes-gpu/src/in_wgpu/init.rs
+++ b/all-is-cubes-gpu/src/in_wgpu/init.rs
@@ -24,12 +24,15 @@ pub async fn create_instance_for_test_or_exit() -> wgpu::Instance {
     });
 
     // Report adapters that we *could* pick
-    _ = writeln!(
-        stderr,
-        "Available adapters (backend filter = {backends:?}):"
-    );
-    for adapter in instance.enumerate_adapters(wgpu::Backends::all()) {
-        _ = writeln!(stderr, "  {}", shortened_adapter_info(&adapter.get_info()));
+    #[cfg(not(target_family = "wasm"))]
+    {
+        _ = writeln!(
+            stderr,
+            "Available adapters (backend filter = {backends:?}):"
+        );
+        for adapter in instance.enumerate_adapters(wgpu::Backends::all()) {
+            _ = writeln!(stderr, "  {}", shortened_adapter_info(&adapter.get_info()));
+        }
     }
 
     let adapter = try_create_adapter_for_test(&instance, |m| _ = writeln!(stderr, "{m}")).await;

--- a/all-is-cubes-gpu/src/in_wgpu/pipelines.rs
+++ b/all-is-cubes-gpu/src/in_wgpu/pipelines.rs
@@ -91,6 +91,9 @@ impl Pipelines {
         // place to ensure that no skew occurs.
         let current_graphics_options = graphics_options.get();
 
+        // Not using pipeline cache (but maybe we should set up hooks for that in the future).
+        let cache: Option<&wgpu::PipelineCache> = None;
+
         let block_texture_entry = |binding| wgpu::BindGroupLayoutEntry {
             binding,
             visibility: wgpu::ShaderStages::FRAGMENT,
@@ -184,11 +187,13 @@ impl Pipelines {
                 vertex: wgpu::VertexState {
                     module: shaders.blocks_and_lines.get(),
                     entry_point: "block_vertex_main",
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
                     buffers: vertex_buffers,
                 },
                 fragment: Some(wgpu::FragmentState {
                     module: shaders.blocks_and_lines.get(),
                     entry_point: "block_fragment_opaque",
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
                     targets: &[Some(wgpu::ColorTargetState {
                         format: fb.linear_scene_texture_format(),
                         blend: None,
@@ -205,6 +210,7 @@ impl Pipelines {
                 }),
                 multisample,
                 multiview: None,
+                cache,
             });
 
         let transparent_render_pipeline =
@@ -214,6 +220,7 @@ impl Pipelines {
                 vertex: wgpu::VertexState {
                     module: shaders.blocks_and_lines.get(),
                     entry_point: "block_vertex_main",
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
                     buffers: vertex_buffers,
                 },
                 fragment: Some(wgpu::FragmentState {
@@ -225,6 +232,7 @@ impl Pipelines {
                         }
                         ref t => panic!("unimplemented transparency option {t:?}"),
                     },
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
                     targets: &[Some(wgpu::ColorTargetState {
                         format: fb.linear_scene_texture_format(),
                         // Note that this blending configuration is for premultiplied alpha.
@@ -255,6 +263,7 @@ impl Pipelines {
                 }),
                 multisample,
                 multiview: None,
+                cache,
             });
 
         let skybox_render_pipeline =
@@ -266,11 +275,13 @@ impl Pipelines {
                 vertex: wgpu::VertexState {
                     module: shaders.blocks_and_lines.get(),
                     entry_point: "skybox_vertex",
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
                     buffers: &[],
                 },
                 fragment: Some(wgpu::FragmentState {
                     module: shaders.blocks_and_lines.get(),
                     entry_point: "skybox_fragment",
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
                     targets: &[Some(wgpu::ColorTargetState {
                         format: fb.linear_scene_texture_format(),
                         blend: None,
@@ -288,6 +299,7 @@ impl Pipelines {
                 }),
                 multisample,
                 multiview: None,
+                cache,
             });
 
         let lines_render_pipeline_layout =
@@ -304,11 +316,13 @@ impl Pipelines {
                 vertex: wgpu::VertexState {
                     module: shaders.blocks_and_lines.get(),
                     entry_point: "lines_vertex",
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
                     buffers: &[WgpuLinesVertex::desc()],
                 },
                 fragment: Some(wgpu::FragmentState {
                     module: shaders.blocks_and_lines.get(),
                     entry_point: "lines_fragment",
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
                     targets: &[Some(wgpu::ColorTargetState {
                         format: fb.linear_scene_texture_format(),
                         blend: None,
@@ -328,6 +342,7 @@ impl Pipelines {
                 }),
                 multisample,
                 multiview: None,
+                cache,
             });
 
         let frame_copy_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
@@ -364,11 +379,13 @@ impl Pipelines {
             vertex: wgpu::VertexState {
                 module: shaders.frame_copy.get(),
                 entry_point: "frame_copy_vertex",
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
                 buffers: &[],
             },
             fragment: Some(wgpu::FragmentState {
                 module: shaders.frame_copy.get(),
                 entry_point: "frame_copy_fragment",
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: wgpu::TextureFormat::Rgba16Float,
                     blend: None,
@@ -382,6 +399,7 @@ impl Pipelines {
             depth_stencil: None,
             multisample,
             multiview: None,
+            cache,
         });
 
         #[cfg(feature = "rerun")]
@@ -442,11 +460,13 @@ impl Pipelines {
             vertex: wgpu::VertexState {
                 module: shaders.rerun_copy.get(),
                 entry_point: "rerun_frame_copy_vertex",
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
                 buffers: &[],
             },
             fragment: Some(wgpu::FragmentState {
                 module: shaders.rerun_copy.get(),
                 entry_point: "rerun_frame_copy_fragment",
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
                 targets: &[
                     Some(wgpu::ColorTargetState {
                         format: wgpu::TextureFormat::Rgba8UnormSrgb,
@@ -468,6 +488,7 @@ impl Pipelines {
             // we're writing *to* a non-multisampled texture
             multisample: wgpu::MultisampleState::default(),
             multiview: None,
+            cache,
         });
 
         let linear_sampler = device.create_sampler(&wgpu::SamplerDescriptor {

--- a/all-is-cubes-gpu/src/in_wgpu/postprocess.rs
+++ b/all-is-cubes-gpu/src/in_wgpu/postprocess.rs
@@ -91,11 +91,13 @@ pub(crate) fn create_postprocess_pipeline(
         vertex: wgpu::VertexState {
             module: shaders.postprocess.get(),
             entry_point: "postprocess_vertex",
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
             buffers: &[],
         },
         fragment: Some(wgpu::FragmentState {
             module: shaders.postprocess.get(),
             entry_point: "postprocess_fragment",
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
             targets: &[Some(wgpu::ColorTargetState {
                 format: super::surface_view_format(surface_format),
                 blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
@@ -115,6 +117,7 @@ pub(crate) fn create_postprocess_pipeline(
         // default = off. No need for multisampling since we are not drawing triangles here.
         multisample: wgpu::MultisampleState::default(),
         multiview: None,
+        cache: None,
     })
 }
 

--- a/all-is-cubes-gpu/src/in_wgpu/shader_testing.rs
+++ b/all-is-cubes-gpu/src/in_wgpu/shader_testing.rs
@@ -93,11 +93,13 @@ where
         vertex: wgpu::VertexState {
             module: &shader,
             entry_point: "block_vertex_main",
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
             buffers: &[WgpuBlockVertex::desc(), WgpuInstanceData::desc()],
         },
         fragment: Some(wgpu::FragmentState {
             module: &shader,
             entry_point: "test_entry_point",
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
             targets: &[Some(wgpu::ColorTargetState {
                 format: fbt.linear_scene_texture_format(),
                 blend: None,
@@ -122,6 +124,7 @@ where
         }),
         multisample: wgpu::MultisampleState::default(), // default = off
         multiview: None,
+        cache: None,
     });
 
     // Placeholder space data for the bind group

--- a/all-is-cubes-wasm/Cargo.lock
+++ b/all-is-cubes-wasm/Cargo.lock
@@ -263,11 +263,11 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "ash"
-version = "0.37.3+1.3.251"
+version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
- "libloading 0.7.4",
+ "libloading",
 ]
 
 [[package]]
@@ -299,18 +299,18 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
 
 [[package]]
 name = "bitflags"
@@ -376,12 +376,6 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "cc"
-version = "1.0.105"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5208975e568d83b6b05cc0a063c8e7e9acc2b43bee6da15616a5b73e109d7437"
 
 [[package]]
 name = "cfg-if"
@@ -507,6 +501,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.69",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -815,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "glutin_wgl_sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead"
+checksum = "0a4e1951bbd9434a81aa496fe59ccc2235af3820d27b85f9314e279609211e2c"
 dependencies = [
  "gl_generator",
 ]
@@ -843,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "gpu-allocator"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f56f6318968d03c18e1bcf4857ff88c61157e9da8e47c5f29055d60e1228884"
+checksum = "fdd4240fc91d3433d5e5b0fc5b67672d771850dc19bbee03c1381e19322803d7"
 dependencies = [
  "log",
  "presser",
@@ -856,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "gpu-descriptor"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
+checksum = "9c08c1f623a8d0b722b8b99f821eb0ba672a1618f0d3b16ddbee1cedd2dd8557"
 dependencies = [
  "bitflags 2.6.0",
  "gpu-descriptor-types",
@@ -867,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "gpu-descriptor-types"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf0b36e6f090b7e1d8a4b49c0cb81c1f8376f72198c65dd3ad9ff3556b8b78c"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -904,7 +907,7 @@ dependencies = [
  "bitflags 2.6.0",
  "com",
  "libc",
- "libloading 0.8.4",
+ "libloading",
  "thiserror",
  "widestring",
  "winapi",
@@ -1017,7 +1020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
 dependencies = [
  "libc",
- "libloading 0.8.4",
+ "libloading",
  "pkg-config",
 ]
 
@@ -1041,16 +1044,6 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if",
- "winapi",
-]
-
-[[package]]
-name = "libloading"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
@@ -1064,6 +1057,12 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
@@ -1120,9 +1119,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "metal"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
+checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
 dependencies = [
  "bitflags 2.6.0",
  "block",
@@ -1179,17 +1178,18 @@ checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
 
 [[package]]
 name = "naga"
-version = "0.19.2"
+version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e3524642f53d9af419ab5e8dd29d3ba155708267667c2f3f06c88c9e130843"
+checksum = "8bd5a652b6faf21496f2cfd88fc49989c8db0825d1f6746b1a71a6ede24a63ad"
 dependencies = [
+ "arrayvec",
  "bit-set",
  "bitflags 2.6.0",
+ "cfg_aliases",
  "codespan-reporting",
  "hexf-parse",
  "indexmap",
  "log",
- "num-traits",
  "rustc-hash",
  "spirv",
  "termcolor",
@@ -1270,16 +1270,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
- "objc_exception",
-]
-
-[[package]]
-name = "objc_exception"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1728,18 +1718,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1895,13 +1885,13 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.19.4"
+version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd7311dbd2abcfebaabf1841a2824ed7c8be443a0f29166e5d3c6a53a762c01"
+checksum = "e1d1c4ba43f80542cf63a0a6ed3134629ae73e8ab51e4b765a67f3aa062eb433"
 dependencies = [
  "arrayvec",
- "cfg-if",
  "cfg_aliases",
+ "document-features",
  "js-sys",
  "log",
  "naga",
@@ -1920,15 +1910,15 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.19.4"
+version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b94525fc99ba9e5c9a9e24764f2bc29bad0911a7446c12f446a8277369bf3a"
+checksum = "0348c840d1051b8e86c3bcd31206080c5e71e5933dabd79be1ce732b0b2f089a"
 dependencies = [
  "arrayvec",
  "bit-vec",
  "bitflags 2.6.0",
  "cfg_aliases",
- "codespan-reporting",
+ "document-features",
  "indexmap",
  "log",
  "naga",
@@ -1939,16 +1929,15 @@ dependencies = [
  "rustc-hash",
  "smallvec",
  "thiserror",
- "web-sys",
  "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "0.19.5"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfabcfc55fd86611a855816326b2d54c3b2fd7972c27ce414291562650552703"
+checksum = "f6bbf4b4de8b2a83c0401d9e5ae0080a2792055f25859a02bf9be97952bbed4f"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -1965,7 +1954,7 @@ dependencies = [
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.8.4",
+ "libloading",
  "log",
  "metal",
  "naga",
@@ -1987,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.19.2"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b671ff9fb03f78b46ff176494ee1ebe7d603393f42664be55b64dc8d53969805"
+checksum = "bc9d91f0e2c4b51434dfa6db77846f2793149d8e73f800fa2e41f52b8eac3c5d"
 dependencies = [
  "bitflags 2.6.0",
  "js-sys",

--- a/all-is-cubes-wasm/Cargo.toml
+++ b/all-is-cubes-wasm/Cargo.toml
@@ -40,20 +40,20 @@ futures-core = "0.3.28"
 # Feature enabling for indirect dependency all-is-cubes → rand → getrandom,
 # as well as our direct dependency
 getrandom = { version = "0.2.7", features = ["js"] }
-js-sys = "0.3.67"
+js-sys = "0.3.69"
 log = { version = "0.4.17", default-features = false }
 rand = { version = "0.8.3", default-features = false, features = ["std", "std_rng"] }
 send_wrapper = "0.6.0"
-wasm-bindgen = "0.2.90"
-wasm-bindgen-futures = "0.4.40"
+wasm-bindgen = "0.2.92"
+wasm-bindgen-futures = "0.4.42"
 web-time = { version = "1.0.0" }
 # Must be the same version as in the main workspace, i.e. as in all-is-cubes-gpu.
-wgpu = { version = "0.19.3", default-features = false, features = ["webgpu", "webgl"] }
+wgpu = { version = "22.1.0", default-features = false, features = ["webgpu", "webgl"] }
 # Feature enabling
 yield-progress = { version = "0.1.6", features = ["log_hiccups"] }
 
 [dependencies.web-sys]
-version = "0.3.67"
+version = "0.3.69"
 features = [
   "console",
   "AddEventListenerOptions",


### PR DESCRIPTION
wgpu now includes https://github.com/gfx-rs/wgpu/pull/5987 as a workaround for `cargo doc` hanging, so we have no reason to hold back, other than duplicated deps due to having older `rend3` in a test. (I don't understand why cargo-deny is not objecting to these duplicates.)