### PR TITLE
CI: Fix GitHub Pages deployment.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,9 +188,8 @@ jobs:
     # (but only for the stablest matrix version)
     - name: Save wasm dist artifact
       if: ${{ matrix.primary }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-pages-artifact@v3
       with:
-        name: wasm-dist
         path: all-is-cubes-wasm/dist
 
     - run: df -h .
@@ -199,8 +198,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+  
     # Do this only if we are pushing to main, not to pull requests.
     # (Or if we're on a special 'pages-alt' branch, so we can experiment with
     # deployment before pushing to main.)
@@ -210,20 +213,10 @@ jobs:
     if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/pages-alt') }}
 
     steps:
-    - name: Download wasm dist artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: wasm-dist
-        path: dist-for-deploy
+    # This action uses the artifact previously uploaded by actions/upload-pages-artifact
     - name: Deploy to GitHub Pages
-      uses: crazy-max/ghaction-github-pages@v4
-      with:
-        target_branch: gh-pages
-        build_dir: dist-for-deploy
-        keep_history: false
-        jekyll: false
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      id: deployment
+      uses: actions/deploy-pages@v4
 
   # Run `xtask lint`.
   #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
     #
     # Caution: GitHub's parsing is weird around multiline expressions so just don't.
     # https://github.community/t/how-to-write-multi-line-condition-in-if/128477
-    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/pages-alt') }}
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.ref == 'refs/heads/pages-alt' }}
 
     steps:
     # This action uses the artifact previously uploaded by actions/upload-pages-artifact


### PR DESCRIPTION
Instead of using a push to the `gh-pages` branch (and a third-party workflow to do so), use the official actions for deploying directly from a workflow artifact.