### PR TITLE
CI: Update version of cargo-mutants in use.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,9 @@ jobs:
       # about caching the builds of them.
       # cargo-mutants is not used in this step but it will be cached for later use.
       run: |
-        cargo install --locked wasm-pack@0.13.0 cargo-about@0.6.1 cargo-mutants@24.7.1
+        cargo install --locked wasm-pack@0.13.0 cargo-about@0.6.1
+        # Not locked so that we can have a newer `syn` than is in the lockfile
+        cargo install cargo-mutants@24.9.0
 
 
     - run: df -h .
@@ -410,7 +412,8 @@ jobs:
 
       # Install cargo-mutants
       # This should usually be already installed, but is present in case of cache miss
-      - run: cargo install --locked cargo-mutants@24.7.1
+      # Not locked so that we can have a newer `syn` than is in the lockfile
+      - run: cargo install cargo-mutants@24.9.0
 
       - name: Relative diff
         run: |

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -22,7 +22,8 @@ jobs:
         run: rustup toolchain install stable --profile=minimal
 
       - name: Install cargo-mutants
-        run: cargo install --locked cargo-mutants@24.7.1
+        # Not locked so that we can have a newer `syn` than is in the lockfile
+        run: cargo install cargo-mutants@24.9.0
 
       - name: Run mutation testing for all-is-cubes
         timeout-minutes: 60


### PR DESCRIPTION
I removed `--locked` so it can pick up a newer version of `syn`, which will hopefully allow parsing `use` bounds.
