### PR TITLE
test-renderers: Delete `rend3` dependency and stub out `gltf-render`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
  "tokio",
  "trycmd",
  "unicode-width 0.2.0",
- "wgpu 23.0.1",
+ "wgpu",
  "winit",
  "yield-progress",
 ]
@@ -203,7 +203,7 @@ dependencies = [
  "futures-util",
  "gloo-timers",
  "half",
- "image 0.25.5",
+ "image",
  "itertools 0.13.0",
  "log",
  "num-traits",
@@ -218,7 +218,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "web-time",
- "wgpu 23.0.1",
+ "wgpu",
 ]
 
 [[package]]
@@ -264,7 +264,7 @@ dependencies = [
  "either",
  "futures-core",
  "gltf-json",
- "image 0.25.5",
+ "image",
  "itertools 0.13.0",
  "log",
  "pretty_assertions",
@@ -273,7 +273,7 @@ dependencies = [
  "snapbox",
  "stl_io",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
 ]
 
@@ -384,7 +384,7 @@ dependencies = [
  "ndk-context",
  "ndk-sys 0.6.0+11769913",
  "num_enum 0.7.3",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -681,20 +681,11 @@ checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
 name = "ash"
-version = "0.37.3+1.3.251"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a"
-dependencies = [
- "libloading 0.7.4",
-]
-
-[[package]]
-name = "ash"
 version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
- "libloading 0.8.6",
+ "libloading",
 ]
 
 [[package]]
@@ -855,21 +846,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bimap"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bindgen"
@@ -891,27 +870,12 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
-]
-
-[[package]]
-name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -1042,7 +1006,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -1099,7 +1063,7 @@ dependencies = [
  "semver 1.0.23",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -1223,7 +1187,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "696283b40e1a39d208ee614b92e5f6521d16962edeb47c48372585ec92419943"
 dependencies = [
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -1234,7 +1198,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.8.6",
+ "libloading",
 ]
 
 [[package]]
@@ -1294,12 +1258,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,37 +1271,6 @@ checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "com"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e17887fd17353b65b1b2ef1c526c83e26cd72e74f598a8dc1bee13a48f3d9f6"
-dependencies = [
- "com_macros",
-]
-
-[[package]]
-name = "com_macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d375883580a668c7481ea6631fc1a8863e33cc335bf56bfad8d7e6d4b04b13a5"
-dependencies = [
- "com_macros_support",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "com_macros_support"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad899a1087a9296d5644792d7cb72b8e34c1bec8e7d4fbc002230169a6e8710c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1422,12 +1349,6 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
-
-[[package]]
-name = "const_panic"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "013b6c2c3a14d678f38cd23994b02da3a1a1b6a5d1eedddfe63a5a5f11b13a81"
 
 [[package]]
 name = "content_inspector"
@@ -1690,17 +1611,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
-name = "d3d12"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e3d747f100290a1ca24b752186f61f6637e1deffe3bf6320de6fcb29510a307"
-dependencies = [
- "bitflags 2.6.0",
- "libloading 0.8.6",
- "winapi",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,27 +1698,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,7 +1731,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.8.6",
+ "libloading",
 ]
 
 [[package]]
@@ -1935,38 +1824,6 @@ checksum = "ba9ecd261f991856250d2207f6d8376946cd9f412a2165d3b75bc87a0bc7a044"
 dependencies = [
  "az",
  "byteorder",
-]
-
-[[package]]
-name = "encase"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fce2eeef77fd4a293a54b62aa00ac9daebfbcda4bf8998c5a815635b004aa1c"
-dependencies = [
- "const_panic",
- "encase_derive",
- "glam 0.24.2",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "encase_derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e520cde08cbf4f7cc097f61573ec06ce467019803de8ae82fb2823fa1554a0e"
-dependencies = [
- "encase_derive_impl",
-]
-
-[[package]]
-name = "encase_derive_impl"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe2568f851fd6144a45fa91cfed8fe5ca8fc0b56ba6797bfc1ed2771b90e37c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
 ]
 
 [[package]]
@@ -2128,12 +1985,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "float-ord"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
-
-[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2141,7 +1992,6 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "nanorand",
  "spin",
 ]
 
@@ -2380,16 +2230,6 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
-dependencies = [
- "bytemuck",
- "mint",
-]
-
-[[package]]
-name = "glam"
 version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc46dd3ec48fdd8e693a98d2b8bafae273a2d54c1de02a2a7e3d57d501f39677"
@@ -2417,18 +2257,6 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
-dependencies = [
- "js-sys",
- "slotmap",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "glow"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51fa363f025f5c111e03f13eda21162faeacb6911fe8caa0c0349f9cf0c4483"
@@ -2448,7 +2276,7 @@ dependencies = [
  "base64 0.13.1",
  "byteorder",
  "gltf-json",
- "image 0.25.5",
+ "image",
  "lazy_static",
  "serde_json",
  "urlencoding",
@@ -2476,15 +2304,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
-]
-
-[[package]]
-name = "glutin_wgl_sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead"
-dependencies = [
- "gl_generator",
 ]
 
 [[package]]
@@ -2517,38 +2336,14 @@ dependencies = [
 
 [[package]]
 name = "gpu-allocator"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f56f6318968d03c18e1bcf4857ff88c61157e9da8e47c5f29055d60e1228884"
-dependencies = [
- "log",
- "presser",
- "thiserror 1.0.69",
- "winapi",
- "windows 0.52.0",
-]
-
-[[package]]
-name = "gpu-allocator"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
 dependencies = [
  "log",
  "presser",
- "thiserror 1.0.69",
+ "thiserror",
  "windows 0.58.0",
-]
-
-[[package]]
-name = "gpu-descriptor"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
-dependencies = [
- "bitflags 2.6.0",
- "gpu-descriptor-types 0.1.2",
- "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2558,17 +2353,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c08c1f623a8d0b722b8b99f821eb0ba672a1618f0d3b16ddbee1cedd2dd8557"
 dependencies = [
  "bitflags 2.6.0",
- "gpu-descriptor-types 0.2.0",
+ "gpu-descriptor-types",
  "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "gpu-descriptor-types"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf0b36e6f090b7e1d8a4b49c0cb81c1f8376f72198c65dd3ad9ff3556b8b78c"
-dependencies = [
- "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -2612,20 +2398,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "handlebars"
-version = "4.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa67bab9ff362228eb3d00bd024a4965d8231bbb7921167f0cfa66c6626b225"
-dependencies = [
- "log",
- "pest",
- "pest_derive",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "hash_hasher"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2656,21 +2428,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
-]
-
-[[package]]
-name = "hassle-rs"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af2a7e73e1f34c48da31fb668a907f250794837e08faa144fd24f0b8b741e890"
-dependencies = [
- "bitflags 2.6.0",
- "com",
- "libc",
- "libloading 0.8.6",
- "thiserror 1.0.69",
- "widestring",
- "winapi",
 ]
 
 [[package]]
@@ -2982,18 +2739,6 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
-dependencies = [
- "bytemuck",
- "byteorder",
- "color_quant",
- "num-traits",
-]
-
-[[package]]
-name = "image"
 version = "0.25.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd6f44aed642f18953a158afeb30206f4d50da59fbc66ecb53c66488de73563b"
@@ -3192,7 +2937,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "thiserror",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -3229,7 +2974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
 dependencies = [
  "libc",
- "libloading 0.8.6",
+ "libloading",
  "pkg-config",
 ]
 
@@ -3246,7 +2991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a9f9dff5e262540b628b00d5e1a772270a962d6869f8695bb24832ff3b394"
 dependencies = [
  "cpal",
- "glam 0.29.2",
+ "glam",
  "mint",
  "paste",
  "ringbuf",
@@ -3332,16 +3077,6 @@ checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if",
- "winapi",
-]
-
-[[package]]
-name = "libloading"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
@@ -3388,12 +3123,6 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
-
-[[package]]
-name = "list-any"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d1d1b0528cc76bed22884ae4f56f5548d80643f848d6df0c652032f7ca6165"
 
 [[package]]
 name = "litemap"
@@ -3524,21 +3253,6 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
-dependencies = [
- "bitflags 2.6.0",
- "block",
- "core-graphics-types",
- "foreign-types",
- "log",
- "objc",
- "paste",
-]
-
-[[package]]
-name = "metal"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
@@ -3636,32 +3350,12 @@ checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
 
 [[package]]
 name = "naga"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e3524642f53d9af419ab5e8dd29d3ba155708267667c2f3f06c88c9e130843"
-dependencies = [
- "bit-set 0.5.3",
- "bitflags 2.6.0",
- "codespan-reporting",
- "hexf-parse",
- "indexmap 2.7.0",
- "log",
- "num-traits",
- "rustc-hash",
- "spirv",
- "termcolor",
- "thiserror 1.0.69",
- "unicode-xid",
-]
-
-[[package]]
-name = "naga"
 version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d5941e45a15b53aad4375eedf02033adb7a28931eedc31117faffa52e6a857e"
 dependencies = [
  "arrayvec",
- "bit-set 0.8.0",
+ "bit-set",
  "bitflags 2.6.0",
  "cfg_aliases 0.1.1",
  "codespan-reporting",
@@ -3671,17 +3365,8 @@ dependencies = [
  "rustc-hash",
  "spirv",
  "termcolor",
- "thiserror 1.0.69",
+ "thiserror",
  "unicode-xid",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -3716,7 +3401,7 @@ dependencies = [
  "log",
  "ndk-sys 0.5.0+25.2.9519653",
  "num_enum 0.7.3",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -3731,7 +3416,7 @@ dependencies = [
  "ndk-sys 0.6.0+11769913",
  "num_enum 0.7.3",
  "raw-window-handle",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -3796,12 +3481,6 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
-
-[[package]]
-name = "noop-waker"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56902c3f29ce7afbecc1d088dfd2e3108033f3c02041c70788ed94280a3d5261"
 
 [[package]]
 name = "normalize-line-endings"
@@ -3984,7 +3663,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
- "objc_exception",
 ]
 
 [[package]]
@@ -4191,15 +3869,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc_exception"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "object"
 version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4242,12 +3911,6 @@ name = "oorandom"
 version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbclient"
@@ -4341,51 +4004,6 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "pest"
-version = "2.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
-dependencies = [
- "memchr",
- "thiserror 2.0.6",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
-dependencies = [
- "once_cell",
- "pest",
- "sha2",
-]
 
 [[package]]
 name = "petgraph"
@@ -4867,7 +4485,7 @@ dependencies = [
  "re_tuid",
  "re_types_core",
  "similar-asserts",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -4929,7 +4547,7 @@ dependencies = [
  "re_smart_channel",
  "re_tracing",
  "rmp-serde",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -4963,7 +4581,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "static_assertions",
- "thiserror 1.0.69",
+ "thiserror",
  "time",
  "typenum",
  "uuid",
@@ -5000,7 +4618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95f75d9831745a5944ef6a338cc3cc06f8d39a83506f943896eaf602ab1166c4"
 dependencies = [
  "prost",
- "thiserror 1.0.69",
+ "thiserror",
  "tonic",
  "tonic-web-wasm-client",
 ]
@@ -5029,7 +4647,7 @@ dependencies = [
  "re_memory",
  "re_sdk_comms",
  "re_types_core",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -5046,7 +4664,7 @@ dependencies = [
  "re_log_encoding",
  "re_log_types",
  "re_smart_channel",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -5130,7 +4748,7 @@ dependencies = [
  "re_types_builder",
  "re_types_core",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror",
  "uuid",
 ]
 
@@ -5190,7 +4808,7 @@ dependencies = [
  "re_tuid",
  "serde",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -5225,7 +4843,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -5262,101 +4880,6 @@ name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
-name = "rend3"
-version = "0.3.0"
-source = "git+https://github.com/BVE-Reborn/rend3/?rev=86bc4d2d2f4048a0adaa9af5ef542dc652308966#86bc4d2d2f4048a0adaa9af5ef542dc652308966"
-dependencies = [
- "arrayvec",
- "bimap",
- "bitflags 2.6.0",
- "bumpalo",
- "bytemuck",
- "encase",
- "flume",
- "glam 0.24.2",
- "handlebars",
- "indexmap 2.7.0",
- "list-any",
- "log",
- "noop-waker",
- "num-traits",
- "once_cell",
- "parking_lot",
- "profiling",
- "range-alloc",
- "rend3-types",
- "rust-embed",
- "rustc-hash",
- "serde",
- "smallvec",
- "smartstring",
- "thiserror 1.0.69",
- "wgpu 0.19.4",
- "wgpu-profiler",
-]
-
-[[package]]
-name = "rend3-gltf"
-version = "0.3.0"
-source = "git+https://github.com/BVE-Reborn/rend3/?rev=86bc4d2d2f4048a0adaa9af5ef542dc652308966#86bc4d2d2f4048a0adaa9af5ef542dc652308966"
-dependencies = [
- "arrayvec",
- "base64 0.21.7",
- "bytemuck",
- "float-ord",
- "glam 0.24.2",
- "gltf",
- "image 0.24.9",
- "log",
- "profiling",
- "rend3",
- "rend3-routine",
- "rustc-hash",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "rend3-routine"
-version = "0.3.0"
-source = "git+https://github.com/BVE-Reborn/rend3/?rev=86bc4d2d2f4048a0adaa9af5ef542dc652308966#86bc4d2d2f4048a0adaa9af5ef542dc652308966"
-dependencies = [
- "arrayvec",
- "bitflags 2.6.0",
- "bytemuck",
- "codespan-reporting",
- "encase",
- "flume",
- "glam 0.24.2",
- "log",
- "naga 0.19.2",
- "ordered-float",
- "parking_lot",
- "profiling",
- "rend3",
- "rust-embed",
- "serde",
- "serde_json",
- "wgpu 0.19.4",
- "wgpu-profiler",
-]
-
-[[package]]
-name = "rend3-types"
-version = "0.3.0"
-source = "git+https://github.com/BVE-Reborn/rend3/?rev=86bc4d2d2f4048a0adaa9af5ef542dc652308966#86bc4d2d2f4048a0adaa9af5ef542dc652308966"
-dependencies = [
- "bitflags 2.6.0",
- "bytemuck",
- "cfg-if",
- "encase",
- "glam 0.24.2",
- "list-any",
- "once_cell",
- "thiserror 1.0.69",
- "wgpu-types 0.19.2",
-]
 
 [[package]]
 name = "renderdoc-sys"
@@ -5471,41 +4994,6 @@ dependencies = [
  "rustc_version",
  "syn 2.0.90",
  "unicode-ident",
-]
-
-[[package]]
-name = "rust-embed"
-version = "8.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0"
-dependencies = [
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "8.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "shellexpand",
- "syn 2.0.90",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "8.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5347777e9aacb56039b0e1f28785929a8a3b709e87482e7442c72e7c12529d"
-dependencies = [
- "sha2",
- "walkdir",
 ]
 
 [[package]]
@@ -5693,15 +5181,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shellexpand"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
-dependencies = [
- "dirs",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5817,17 +5296,6 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "smartstring"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
-dependencies = [
- "autocfg",
- "static_assertions",
- "version_check",
-]
 
 [[package]]
 name = "smol_str"
@@ -6061,18 +5529,12 @@ dependencies = [
  "bytemuck",
  "clap",
  "exhaust",
- "futures-channel",
  "futures-core",
  "futures-util",
- "glam 0.24.2",
- "image 0.25.5",
+ "image",
  "imgref",
  "itertools 0.13.0",
  "log",
- "mint",
- "rend3",
- "rend3-gltf",
- "rend3-routine",
  "rendiff",
  "send_wrapper",
  "serde",
@@ -6082,8 +5544,7 @@ dependencies = [
  "time",
  "tinytemplate",
  "tokio",
- "wgpu 0.19.4",
- "wgpu 23.0.1",
+ "wgpu",
 ]
 
 [[package]]
@@ -6092,16 +5553,7 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
-dependencies = [
- "thiserror-impl 2.0.6",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -6109,17 +5561,6 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6323,7 +5764,7 @@ dependencies = [
  "httparse",
  "js-sys",
  "pin-project",
- "thiserror 1.0.69",
+ "thiserror",
  "tonic",
  "tower-service",
  "wasm-bindgen",
@@ -6485,12 +5926,6 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"
@@ -6739,31 +6174,6 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.19.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd7311dbd2abcfebaabf1841a2824ed7c8be443a0f29166e5d3c6a53a762c01"
-dependencies = [
- "arrayvec",
- "cfg-if",
- "cfg_aliases 0.1.1",
- "js-sys",
- "log",
- "naga 0.19.2",
- "parking_lot",
- "profiling",
- "raw-window-handle",
- "smallvec",
- "static_assertions",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "wgpu-core 0.19.4",
- "wgpu-hal 0.19.5",
- "wgpu-types 0.19.2",
-]
-
-[[package]]
-name = "wgpu"
 version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80f70000db37c469ea9d67defdc13024ddf9a5f1b89cb2941b812ad7cde1735a"
@@ -6781,35 +6191,9 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "wgpu-core 23.0.1",
- "wgpu-hal 23.0.1",
- "wgpu-types 23.0.0",
-]
-
-[[package]]
-name = "wgpu-core"
-version = "0.19.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b94525fc99ba9e5c9a9e24764f2bc29bad0911a7446c12f446a8277369bf3a"
-dependencies = [
- "arrayvec",
- "bit-vec 0.6.3",
- "bitflags 2.6.0",
- "cfg_aliases 0.1.1",
- "codespan-reporting",
- "indexmap 2.7.0",
- "log",
- "naga 0.19.2",
- "once_cell",
- "parking_lot",
- "profiling",
- "raw-window-handle",
- "rustc-hash",
- "smallvec",
- "thiserror 1.0.69",
- "web-sys",
- "wgpu-hal 0.19.5",
- "wgpu-types 0.19.2",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
 ]
 
 [[package]]
@@ -6819,67 +6203,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d63c3c478de8e7e01786479919c8769f62a22eec16788d8c2ac77ce2c132778a"
 dependencies = [
  "arrayvec",
- "bit-vec 0.8.0",
+ "bit-vec",
  "bitflags 2.6.0",
  "cfg_aliases 0.1.1",
  "document-features",
  "indexmap 2.7.0",
  "log",
- "naga 23.0.0",
+ "naga",
  "once_cell",
  "parking_lot",
  "profiling",
  "raw-window-handle",
  "rustc-hash",
  "smallvec",
- "thiserror 1.0.69",
- "wgpu-hal 23.0.1",
- "wgpu-types 23.0.0",
-]
-
-[[package]]
-name = "wgpu-hal"
-version = "0.19.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfabcfc55fd86611a855816326b2d54c3b2fd7972c27ce414291562650552703"
-dependencies = [
- "android_system_properties",
- "arrayvec",
- "ash 0.37.3+1.3.251",
- "bit-set 0.5.3",
- "bitflags 2.6.0",
- "block",
- "cfg_aliases 0.1.1",
- "core-graphics-types",
- "d3d12",
- "glow 0.13.1",
- "glutin_wgl_sys 0.5.0",
- "gpu-alloc",
- "gpu-allocator 0.25.0",
- "gpu-descriptor 0.2.4",
- "hassle-rs",
- "js-sys",
- "khronos-egl",
- "libc",
- "libloading 0.8.6",
- "log",
- "metal 0.27.0",
- "naga 0.19.2",
- "ndk-sys 0.5.0+25.2.9519653",
- "objc",
- "once_cell",
- "parking_lot",
- "profiling",
- "range-alloc",
- "raw-window-handle",
- "renderdoc-sys",
- "rustc-hash",
- "smallvec",
- "thiserror 1.0.69",
- "wasm-bindgen",
- "web-sys",
- "wgpu-types 0.19.2",
- "winapi",
+ "thiserror",
+ "wgpu-hal",
+ "wgpu-types",
 ]
 
 [[package]]
@@ -6890,25 +6229,25 @@ checksum = "89364b8a0b211adc7b16aeaf1bd5ad4a919c1154b44c9ce27838213ba05fd821"
 dependencies = [
  "android_system_properties",
  "arrayvec",
- "ash 0.38.0+1.3.281",
- "bit-set 0.8.0",
+ "ash",
+ "bit-set",
  "bitflags 2.6.0",
  "block",
  "bytemuck",
  "cfg_aliases 0.1.1",
  "core-graphics-types",
- "glow 0.14.2",
- "glutin_wgl_sys 0.6.0",
+ "glow",
+ "glutin_wgl_sys",
  "gpu-alloc",
- "gpu-allocator 0.27.0",
- "gpu-descriptor 0.3.0",
+ "gpu-allocator",
+ "gpu-descriptor",
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.8.6",
+ "libloading",
  "log",
- "metal 0.29.0",
- "naga 23.0.0",
+ "metal",
+ "naga",
  "ndk-sys 0.5.0+25.2.9519653",
  "objc",
  "once_cell",
@@ -6919,34 +6258,12 @@ dependencies = [
  "renderdoc-sys",
  "rustc-hash",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror",
  "wasm-bindgen",
  "web-sys",
- "wgpu-types 23.0.0",
+ "wgpu-types",
  "windows 0.58.0",
  "windows-core 0.58.0",
-]
-
-[[package]]
-name = "wgpu-profiler"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198b96a1940b527c6e21ab829b3630eb4e8ffb602fd12839d8c5e088c8e06192"
-dependencies = [
- "parking_lot",
- "thiserror 1.0.69",
- "wgpu 0.19.4",
-]
-
-[[package]]
-name = "wgpu-types"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b671ff9fb03f78b46ff176494ee1ebe7d603393f42664be55b64dc8d53969805"
-dependencies = [
- "bitflags 2.6.0",
- "js-sys",
- "web-sys",
 ]
 
 [[package]]
@@ -6959,12 +6276,6 @@ dependencies = [
  "js-sys",
  "web-sys",
 ]
-
-[[package]]
-name = "widestring"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
 
 [[package]]
 name = "winapi"
@@ -7127,15 +6438,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -7428,7 +6730,7 @@ dependencies = [
  "as-raw-xcb-connection",
  "gethostname",
  "libc",
- "libloading 0.8.6",
+ "libloading",
  "once_cell",
  "rustix",
  "x11rb-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ thiserror = { version = "1.0.65", default-features = false }
 time = { version = "0.3.36", default-features = false }
 # Tokio is used for async test-running and for certain binaries.
 # The library crates do not require Tokio.
-tokio = { version = "1.28.0", default-features = false }
+tokio = { version = "1.34.0", default-features = false }
 trycmd = "0.15.4" # keep in sync with `snapbox`
 unicode-segmentation = { version = "1.10.1", default-features = false }
 unicode-width = { version = "0.2", default-features = false }

--- a/test-renderers/Cargo.toml
+++ b/test-renderers/Cargo.toml
@@ -53,13 +53,6 @@ auto-threads = [
 gltf = [
     "dep:all-is-cubes-port",
     "dep:bytemuck",
-    "dep:futures-channel",
-    "dep:rend3",
-    "dep:rend3-gltf",
-    "dep:rend3-routine",
-    "dep:glam", # activates mint feature for interop
-    "dep:mint",
-    "dep:wgpu_for_rend3",
     "tokio/fs",
 ]
 
@@ -77,18 +70,12 @@ bytemuck = { workspace = true, optional = true }
 clap = { workspace = true }
 exhaust = { workspace = true }
 futures-core = { workspace = true }
-futures-channel = { workspace = true, optional = true }
+#futures-channel = { workspace = true, optional = true }
 futures-util = { workspace = true, features = ["std"] }
-# Must be the same version of glam as rend3 uses
-glam = { version = "0.24", optional = true, features = ["mint"] }
 image = { workspace = true, features = ["png"] }
 imgref = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
-mint = { version = "0.5.9", optional = true }
-rend3 = { git = "https://github.com/BVE-Reborn/rend3/", rev = "86bc4d2d2f4048a0adaa9af5ef542dc652308966", optional = true }
-rend3-gltf = { git = "https://github.com/BVE-Reborn/rend3/", rev = "86bc4d2d2f4048a0adaa9af5ef542dc652308966",  optional = true, default-features = false }
-rend3-routine = { git = "https://github.com/BVE-Reborn/rend3/", rev = "86bc4d2d2f4048a0adaa9af5ef542dc652308966", optional = true }
 rendiff = { workspace = true }
 send_wrapper = { workspace = true }
 serde = { workspace = true }
@@ -104,7 +91,6 @@ tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "park
 # In addition to depending on wgpu directly, we also need to select backends to be enabled in our binary.
 # (As of wgpu 0.19, Vulkan is implicitly enabled on Linux.)
 wgpu = { workspace = true, features = ["dx12", "metal"] }
-wgpu_for_rend3 = { package = "wgpu", version = "0.19", optional = true, features = ["dx12", "metal"] }
 
 [lints]
 workspace = true

--- a/test-renderers/tests/gltf-render.rs
+++ b/test-renderers/tests/gltf-render.rs
@@ -1,5 +1,9 @@
-//! Runs [`test_renderers::harness_main`] against glTF files produced by [`all_is_cubes_port`]
-//! and rendered by [`rend3`].
+//! Runs [`test_renderers::harness_main`] against glTF files produced by [`all_is_cubes_port`].
+//!
+//! Or rather, it would if we had a glTF renderer.
+//! The previous half-working implementation has been removed due to lack of maintenance;
+//! this test will always fail.
+//! TODO: Build a new implementation.
 //!
 //! Note that in order to run this test, the `gltf` feature must be enabled.
 
@@ -9,7 +13,6 @@ use std::sync::Arc;
 
 use clap::Parser as _;
 use futures_core::future::BoxFuture;
-use wgpu_for_rend3 as wgpu;
 
 use all_is_cubes::space::{Sky, Space};
 use all_is_cubes::universe::Handle;
@@ -18,8 +21,6 @@ use all_is_cubes_port as port;
 use all_is_cubes_render::camera::StandardCameras;
 use all_is_cubes_render::{Flaws, HeadlessRenderer, RenderError, Rendering};
 use test_renderers::{RendererFactory, RendererId};
-
-const TEXTURE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
 
 #[tokio::main]
 async fn main() -> test_renderers::HarnessResult {
@@ -37,22 +38,12 @@ async fn main() -> test_renderers::HarnessResult {
     .await
 }
 
-async fn get_factory() -> GltfFactory {
-    match rend3::create_iad(None, None, None, None).await {
-        Ok(iad) => GltfFactory { iad },
-        Err(rend3::RendererInitializationError::MissingAdapter) => {
-            // TODO: harness should support fallibility here
-            eprintln!("Skipping rendering tests due to lack of wgpu::Adapter.");
-            std::process::exit(0);
-        }
-        Err(e) => panic!("{e}", e = all_is_cubes::util::ErrorChain(&e)),
-    }
+async fn get_factory(_label: String) -> GltfFactory {
+    GltfFactory {}
 }
 
 #[derive(Clone)]
-struct GltfFactory {
-    iad: rend3::InstanceAdapterDevice,
-}
+struct GltfFactory {}
 
 impl fmt::Debug for GltfFactory {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -62,44 +53,13 @@ impl fmt::Debug for GltfFactory {
 
 impl RendererFactory for GltfFactory {
     fn renderer_from_cameras(&self, cameras: StandardCameras) -> Box<dyn HeadlessRenderer + Send> {
-        let renderer = rend3::Renderer::new(
-            self.iad.clone(),
-            rend3::types::Handedness::Right,
-            Some(cameras.viewport().nominal_aspect_ratio() as f32),
-        )
-        .unwrap();
-
-        // Initialize rend3 renderer state/features
-
-        let mut spp = rend3::ShaderPreProcessor::new();
-        rend3_routine::builtin_shaders(&mut spp);
-
-        let base_rendergraph = rend3_routine::base::BaseRenderGraph::new(&renderer, &spp);
-        let pbr_routine = rend3_routine::pbr::PbrRoutine::new(
-            &renderer,
-            &mut renderer.data_core.lock(),
-            &spp,
-            &base_rendergraph.interfaces,
-            &base_rendergraph.gpu_culler.culling_buffer_map_handle,
-        );
-        let tonemapping_routine = rend3_routine::tonemapping::TonemappingRoutine::new(
-            &renderer,
-            &spp,
-            &base_rendergraph.interfaces,
-            TEXTURE_FORMAT,
-        );
-
         Box::new(GltfRend3Renderer {
             gltf_dir: Arc::new(
                 tempfile::tempdir().expect("failed to create temporary directory for glTF data"),
             ),
             gltf_output: None,
-            renderer,
             cameras,
             sky: Sky::Uniform(palette::NO_WORLD_TO_SHOW.to_rgb()),
-            base_rendergraph,
-            pbr_routine,
-            tonemapping_routine,
         })
     }
 
@@ -114,12 +74,7 @@ struct GltfRend3Renderer {
     gltf_output: Option<GltfOutput>,
 
     cameras: StandardCameras,
-    renderer: Arc<rend3::Renderer>,
     sky: Sky,
-
-    base_rendergraph: rend3_routine::base::BaseRenderGraph,
-    pbr_routine: rend3_routine::pbr::PbrRoutine,
-    tonemapping_routine: rend3_routine::tonemapping::TonemappingRoutine,
 }
 
 struct GltfOutput {
@@ -128,15 +83,7 @@ struct GltfOutput {
 }
 
 impl GltfRend3Renderer {
-    async fn load_latest_gltf(
-        &mut self,
-    ) -> Result<
-        (
-            Option<(rend3_gltf::LoadedGltfScene, rend3_gltf::GltfSceneInstance)>,
-            Flaws,
-        ),
-        RenderError,
-    > {
+    async fn load_latest_gltf(&mut self) -> Result<(Option<()>, Flaws), RenderError> {
         match &self.gltf_output {
             &Some(GltfOutput { ref path, flaws }) => {
                 let gltf_json_data: Vec<u8> = tokio::fs::read(path)
@@ -144,73 +91,28 @@ impl GltfRend3Renderer {
                     .expect("failed to read glTF JSON");
                 let parent_dir = path.parent().unwrap().to_owned();
 
-                match rend3_gltf::load_gltf(
-                    &self.renderer,
-                    &gltf_json_data,
-                    &rend3_gltf::GltfLoadSettings::default(),
-                    move |url| {
-                        let parent_dir = parent_dir.clone();
-                        async move {
-                            rend3_gltf::filesystem_io_func(&parent_dir, url.as_str()).await
-                        }
-                    },
-                )
-                .await {
-                    Ok(si) => Ok((Some(si), flaws)),
-                    Err(rend3_gltf::GltfLoadError::GltfSingleSceneOnly) => {
-                        Ok((None, Flaws::empty()))
-                    }
-                    Err(e) => panic!("{e:?}"), // TODO: convert to RenderError
-                }
+                // match rend3_gltf::load_gltf(
+                //     &self.renderer,
+                //     &gltf_json_data,
+                //     &rend3_gltf::GltfLoadSettings::default(),
+                //     move |url| {
+                //         let parent_dir = parent_dir.clone();
+                //         async move {
+                //             rend3_gltf::filesystem_io_func(&parent_dir, url.as_str()).await
+                //         }
+                //     },
+                // )
+                // .await {
+                //     Ok(si) => Ok((Some(si), flaws)),
+                //     Err(rend3_gltf::GltfLoadError::GltfSingleSceneOnly) => {
+                //         Ok((None, Flaws::empty()))
+                //     }
+                //     Err(e) => panic!("{e:?}"), // TODO: convert to RenderError
+                // }
+                Ok((None, Flaws::UNFINISHED))
             }
             None => Ok((None, Flaws::UNFINISHED)),
         }
-    }
-
-    fn render_to_rend3(&mut self, frame_texture: &wgpu::Texture) {
-        let renderer = &mut self.renderer;
-        let size = glam::UVec2 {
-            x: frame_texture.width(),
-            y: frame_texture.height(),
-        };
-
-        renderer.swap_instruction_buffers();
-        let mut eval_output = renderer.evaluate_instructions();
-
-        let mut graph = rend3::graph::RenderGraph::new();
-
-        let frame_handle = graph.add_imported_render_target(
-            frame_texture,
-            0..1,
-            0..1,
-            rend3::graph::ViewportRect::from_size(size),
-        );
-        self.base_rendergraph.add_to_graph(
-            &mut graph,
-            rend3_routine::base::BaseRenderGraphInputs {
-                eval_output: &eval_output,
-                routines: rend3_routine::base::BaseRenderGraphRoutines {
-                    pbr: &self.pbr_routine,
-                    skybox: None,
-                    tonemapping: &self.tonemapping_routine,
-                },
-                target: rend3_routine::base::OutputRenderTarget {
-                    handle: frame_handle,
-                    resolution: size,
-                    samples: rend3::types::SampleCount::One, // TODO: respect graphics options
-                },
-            },
-            rend3_routine::base::BaseRenderGraphSettings {
-                // TODO: We would like to export and then render baked lighting, but for now,
-                // just use white ambient lighting to obtain LightingOption::None-like behavior
-                // TODO: Put that in [`Flaws`].
-                ambient_color: glam::Vec4::splat(1.0),
-                // TODO: create skybox object
-                clear_color: glam::Vec4::from(<[f32; 4]>::from(self.sky.mean().with_alpha_one())),
-            },
-        );
-
-        graph.execute(renderer, &mut eval_output);
     }
 }
 
@@ -263,214 +165,48 @@ impl HeadlessRenderer for GltfRend3Renderer {
             let aic_camera = &self.cameras.cameras().world;
             let viewport = aic_camera.viewport();
 
-            if viewport.pixel_count() == Some(0) {
-                // Empty viewport; must not try to use the GPU at all.
-                return Ok(Rendering {
-                    size: viewport.framebuffer_size,
-                    data: Vec::new(),
-                    flaws: Flaws::empty(),
-                });
-            }
+            unimplemented!("gltf-render test has no renderer and is stubbed out");
 
-            self.renderer.set_camera_data(convert_camera(aic_camera));
-
-            let (_objects, mut flaws) = self.load_latest_gltf().await?;
-
-            if !info_text.is_empty() {
-                flaws |= Flaws::OTHER; // TODO: should have a flaw for this, or just actually implement it
-            }
-
-            // not bothering to reuse texture
-            let frame_texture = self
-                .renderer
-                .device
-                .create_texture(&wgpu::TextureDescriptor {
-                    label: None,
-                    size: wgpu::Extent3d {
-                        width: viewport.framebuffer_size.width.max(1),
-                        height: viewport.framebuffer_size.height.max(1),
-                        depth_or_array_layers: 1,
-                    },
-                    mip_level_count: 1,
-                    sample_count: 1,
-                    dimension: wgpu::TextureDimension::D2,
-                    format: TEXTURE_FORMAT,
-                    view_formats: &[],
-                    usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
-                });
-
-            self.render_to_rend3(&frame_texture);
-
-            let rendering = old_wgpu_helpers::get_image_from_gpu(
-                &self.renderer.device,
-                &self.renderer.queue,
-                &frame_texture,
-                flaws,
-            )
-            .await;
+            let rendering = todo!();
+            // let rendering = old_wgpu_helpers::get_image_from_gpu(
+            //     &self.renderer.device,
+            //     &self.renderer.queue,
+            //     &frame_texture,
+            //     flaws,
+            // )
+            // .await;
 
             Ok(rendering)
         })
     }
 }
 
-fn convert_camera(aic_camera: &all_is_cubes_render::camera::Camera) -> rend3::types::Camera {
-    // TODO: This conversion, or something else about the camera data path, is sometimes just mysteriously not working.
-
-    // Convert translation
-    let view_translation: mint::Vector3<f32> =
-        (-aic_camera.view_position().to_f32().to_vector()).into();
-    let translation_matrix = glam::Mat4::from_translation(view_translation.into());
-
-    // Convert rotation
-    let rot_quat = aic_camera.view_transform().rotation;
-    let rotation_matrix = glam::Mat4::from_quat(
-        glam::Quat::from_xyzw(
-            rot_quat.i as f32,
-            rot_quat.j as f32,
-            rot_quat.k as f32,
-            rot_quat.r as f32,
-        )
-        .normalize(),
-    );
-
-    rend3::types::Camera {
-        // TODO: pass a converted projection matrix instead
-        projection: rend3::types::CameraProjection::Perspective {
-            vfov: aic_camera.options().fov_y.into_inner() as f32,
-            near: 0.1,
-        },
-        view: rotation_matrix * translation_matrix,
-    }
-}
-
-/// This is a copy and paste of all-is-cubes-gpu/src/in_wgpu/init.rs
-/// except that it uses `rend3`'s version of wgpu instead. Yes
-mod old_wgpu_helpers {
-    use super::*;
-    use all_is_cubes_render::camera;
-    use std::future::Future;
-    use std::sync::Arc;
-
-    /// Copy the contents of a texture into a [`Rendering`],
-    /// assuming that its byte layout is RGBA8.
-    ///
-    /// Panics if the pixel type or viewport size are incorrect.
-    #[doc(hidden)]
-    pub fn get_image_from_gpu(
-        device: &Arc<wgpu::Device>,
-        queue: &wgpu::Queue,
-        texture: &wgpu::Texture,
-        flaws: Flaws,
-    ) -> impl Future<Output = Rendering> + 'static {
-        // By making this an explicit `Future` return we avoid capturing the queue and texture
-        // references.
-
-        let size = camera::ImageSize::new(texture.width(), texture.height());
-        let data_future = get_texels_from_gpu::<[u8; 4]>(device, queue, texture, 1);
-
-        async move {
-            Rendering {
-                size,
-                data: data_future.await,
-                flaws,
-            }
-        }
-    }
-
-    /// Fetch the contents of a 2D texture, assuming that its byte layout is the same as that
-    /// of `[C; components]` and returning a vector of length
-    /// `dimensions.x * dimensions.y * components`.
-    ///
-    /// Panics if the provided sizes are incorrect.
-    #[doc(hidden)]
-    pub fn get_texels_from_gpu<C>(
-        device: &Arc<wgpu::Device>,
-        queue: &wgpu::Queue,
-        texture: &wgpu::Texture,
-        components: usize,
-    ) -> impl Future<Output = Vec<C>> + 'static
-    where
-        C: bytemuck::AnyBitPattern,
-    {
-        // By making this an explicit `Future` return we avoid capturing the queue and texture
-        // references.
-
-        let dimensions = camera::ImageSize::new(texture.width(), texture.height());
-        assert_eq!(texture.depth_or_array_layers(), 1);
-
-        // Check that the format matches
-        let format = texture.format();
-        let size_of_texel = components * size_of::<C>();
-        assert_eq!(
-            (format.block_copy_size(None), format.block_dimensions()),
-            (Some(size_of_texel as u32), (1, 1)),
-            "Texture format does not match requested size",
-        );
-
-        let dense_bytes_per_row = dimensions.width * u32::try_from(size_of_texel).unwrap();
-        let padded_bytes_per_row = dense_bytes_per_row.div_ceil(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT)
-            * wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
-
-        let temp_buffer = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("GPU-to-CPU image copy buffer"),
-            size: u64::from(padded_bytes_per_row) * u64::from(dimensions.height),
-            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
-            mapped_at_creation: false,
-        });
-
-        {
-            let mut encoder =
-                device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
-            encoder.copy_texture_to_buffer(
-                texture.as_image_copy(),
-                wgpu::ImageCopyBuffer {
-                    buffer: &temp_buffer,
-                    layout: wgpu::ImageDataLayout {
-                        offset: 0,
-                        bytes_per_row: Some(padded_bytes_per_row),
-                        rows_per_image: None,
-                    },
-                },
-                texture.size(),
-            );
-            queue.submit(Some(encoder.finish()));
-        }
-
-        // Start the buffer mapping
-        let (sender, receiver) = futures_channel::oneshot::channel();
-        temp_buffer
-            .slice(..)
-            .map_async(wgpu::MapMode::Read, |result| {
-                let _ = sender.send(result);
-            });
-        device.poll(wgpu::Maintain::Wait);
-
-        // Await the buffer being available and build the image.
-        async move {
-            receiver
-                .await
-                .expect("communication failed")
-                .expect("buffer reading failed");
-            let mapped: &[u8] = &temp_buffer.slice(..).get_mapped_range();
-
-            let element_count = camera::area_usize(dimensions).unwrap() * components;
-
-            // Copy the mapped buffer data into a Rust vector, removing row padding if present
-            // by copying it one row at a time.
-            let mut texel_vector: Vec<C> = Vec::with_capacity(element_count);
-            for row in 0..dimensions.height {
-                let byte_start_of_row = padded_bytes_per_row * row;
-                // TODO: this cast_slice() could fail if `C`’s alignment is higher than the buffer.
-                texel_vector.extend(bytemuck::cast_slice::<u8, C>(
-                    &mapped[byte_start_of_row as usize..][..dense_bytes_per_row as usize],
-                ));
-            }
-            debug_assert_eq!(texel_vector.len(), element_count);
-
-            temp_buffer.destroy();
-
-            texel_vector
-        }
-    }
-}
+// fn convert_camera(aic_camera: &all_is_cubes_render::camera::Camera) -> rend3::types::Camera {
+//     // TODO: This conversion, or something else about the camera data path, is sometimes just mysteriously not working.
+//
+//     // Convert translation
+//     let view_translation: mint::Vector3<f32> =
+//         (-aic_camera.view_position().to_f32().to_vector()).into();
+//     let translation_matrix = glam::Mat4::from_translation(view_translation.into());
+//
+//     // Convert rotation
+//     let rot_quat = aic_camera.view_transform().rotation;
+//     let rotation_matrix = glam::Mat4::from_quat(
+//         glam::Quat::from_xyzw(
+//             rot_quat.i as f32,
+//             rot_quat.j as f32,
+//             rot_quat.k as f32,
+//             rot_quat.r as f32,
+//         )
+//         .normalize(),
+//     );
+//
+//     rend3::types::Camera {
+//         // TODO: pass a converted projection matrix instead
+//         projection: rend3::types::CameraProjection::Perspective {
+//             vfov: aic_camera.options().fov_y.into_inner() as f32,
+//             near: 0.1,
+//         },
+//         view: rotation_matrix * translation_matrix,
+//     }
+// }

--- a/tools/deny.toml
+++ b/tools/deny.toml
@@ -32,16 +32,9 @@ allow-wildcard-paths = true
 # external-default-features = "warn"
 
 skip = [
-    { name = "itertools" },
     { name = "sync_wrapper" },
     { name = "cfg_aliases" }, # winit and wgpu use different versions
-    { name = "wasi" }, # not actually used on our targets
-    { name = "syn", version = "1" },
-    { name = "libloading" },
-    { name = "redox_syscall", version = "=0.4.1" },
     { name = "base64", version = "0.13.1" }, # old used by `embed-doc-image`
-    { name = "heck" }, # old used by strum
-    { name = "miniz_oxide", version = "0.4.4" }, # old used by png-decoder
     { name = "unicode-width", version = "0.1" }, # old used by `codespan-reporting` via `wgpu`
 ]
 


### PR DESCRIPTION
`rend3` is not being updated and is inconveniencing our dependency updates, and the glTF tests never really worked right at all. So, for now, I am making them entirely non-functional and dropping the `rend3` dependency.

Arguably I should be deleting the tests entirely, but I hope to have a chance of getting them back to sort-of-working soonish, just not quite as quickly as I want the old deps gone.