### PR TITLE
gpu: Make `LightTexture::update_scatter()` work in chunks instead of single texels.     

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,7 @@ dependencies = [
  "rand_xoshiro",
  "rayon",
  "resource",
+ "rstest",
  "scopeguard",
  "send_wrapper",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ thiserror = { version = "1.0.65", default-features = false }
 time = { version = "0.3.36", default-features = false }
 # Tokio is used for async test-running and for certain binaries.
 # The library crates do not require Tokio.
-tokio = { version = "1.34.0", default-features = false }
+tokio = { version = "1.42.0", default-features = false }
 trycmd = "0.15.4" # keep in sync with `snapbox`
 unicode-segmentation = { version = "1.10.1", default-features = false }
 unicode-width = { version = "0.2", default-features = false }

--- a/all-is-cubes-gpu/Cargo.toml
+++ b/all-is-cubes-gpu/Cargo.toml
@@ -94,6 +94,7 @@ wgpu = { workspace = true, optional = true }
 criterion = { workspace = true, features = ["async_tokio"] }
 # Used in shader tests. TODO: Not really necessary
 image = { workspace = true }
+rstest = { workspace = true }
 # Used in benchmark
 scopeguard = { workspace = true }
 # Using tokio for async test-running.

--- a/all-is-cubes-gpu/benches/wgpu.rs
+++ b/all-is-cubes-gpu/benches/wgpu.rs
@@ -148,7 +148,8 @@ fn light_benches(runtime: &Runtime, c: &mut Criterion, instance: &wgpu::Instance
         // We're reusing one texture across these tests because it has no observable state that
         // influences the benchmark other than the mapped region state,
         // and we're not primarily interested in effects like "the light data isn't in cache".
-        let mut texture = LightTexture::new("lt", &device, bounds.size());
+        let mut texture =
+            LightTexture::new("lt", &device, bounds.size(), wgpu::TextureUsages::empty());
         let space = Space::builder(bounds).build();
 
         b.iter_with_large_drop(|| {
@@ -163,7 +164,8 @@ fn light_benches(runtime: &Runtime, c: &mut Criterion, instance: &wgpu::Instance
     });
 
     g.bench_function("scatter", |b| {
-        let mut texture = LightTexture::new("lt", &device, bounds.size());
+        let mut texture =
+            LightTexture::new("lt", &device, bounds.size(), wgpu::TextureUsages::empty());
         let space = Space::builder(bounds).build();
 
         // update_scatter() will do nothing if not mapped first

--- a/all-is-cubes-gpu/src/in_wgpu.rs
+++ b/all-is-cubes-gpu/src/in_wgpu.rs
@@ -52,7 +52,7 @@ pub mod headless;
 pub mod init;
 mod light_texture;
 #[doc(hidden)] // public for benchmark
-pub use light_texture::LightTexture;
+pub use light_texture::{LightChunk, LightTexture};
 mod pipelines;
 mod poll;
 mod postprocess;

--- a/all-is-cubes-gpu/src/in_wgpu/light_texture.rs
+++ b/all-is-cubes-gpu/src/in_wgpu/light_texture.rs
@@ -110,7 +110,12 @@ impl LightTexture {
     }
 
     /// Construct a new texture of the specified size with no data.
-    pub fn new(label_prefix: &str, device: &wgpu::Device, size: GridSize) -> Self {
+    pub fn new(
+        label_prefix: &str,
+        device: &wgpu::Device,
+        size: GridSize,
+        additional_usage: wgpu::TextureUsages,
+    ) -> Self {
         let texture = device.create_texture(&wgpu::TextureDescriptor {
             size: size3d_to_extent(size),
             mip_level_count: 1,
@@ -118,7 +123,9 @@ impl LightTexture {
             dimension: wgpu::TextureDimension::D3,
             format: wgpu::TextureFormat::Rgba8Uint,
             view_formats: &[],
-            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_DST
+                | additional_usage,
             label: Some(&format!("{label_prefix} space light")),
         });
         Self {
@@ -144,7 +151,7 @@ impl LightTexture {
             // deallocated promptly before the new allocation is created, keeping peak usage lower.
             self.texture.destroy();
 
-            *self = Self::new(label_prefix, device, size);
+            *self = Self::new(label_prefix, device, size, self.texture.usage());
         }
     }
 
@@ -398,6 +405,11 @@ impl LightTexture {
         }
 
         total_count
+    }
+
+    #[doc(hidden)] // for tests
+    pub fn texture(&self) -> &wgpu::Texture {
+        &self.texture
     }
 
     pub(crate) fn texture_view(&self) -> &Identified<wgpu::TextureView> {

--- a/all-is-cubes-gpu/src/in_wgpu/shader_testing.rs
+++ b/all-is-cubes-gpu/src/in_wgpu/shader_testing.rs
@@ -140,7 +140,7 @@ where
         &device,
         &pipelines,
         &texture_view,
-        &in_wgpu::LightTexture::new("shader test space", &device, GridSize::splat(1)),
+        &in_wgpu::LightTexture::new("shader test space", &device, GridSize::splat(1), wgpu::TextureUsages::empty()),
         in_wgpu::skybox::Skybox::new(&device, "shader test space").texture_view(),
     );
 

--- a/all-is-cubes-gpu/src/in_wgpu/space.rs
+++ b/all-is-cubes-gpu/src/in_wgpu/space.rs
@@ -115,7 +115,12 @@ impl<I: time::Instant> SpaceRenderer<I> {
         block_texture: AtlasAllocator,
         interactive: bool,
     ) -> Self {
-        let light_texture = LightTexture::new(&space_label, device, GridSize::splat(1)); // dummy
+        let light_texture = LightTexture::new(
+            &space_label,
+            device,
+            GridSize::splat(1),
+            wgpu::TextureUsages::empty(),
+        ); // dummy
 
         let camera_buffer = SpaceCameraBuffer::new(&space_label, device, pipelines);
 

--- a/all-is-cubes-gpu/src/in_wgpu/space.rs
+++ b/all-is-cubes-gpu/src/in_wgpu/space.rs
@@ -11,8 +11,8 @@ use all_is_cubes::chunking::ChunkPos;
 use all_is_cubes::content::palette;
 use all_is_cubes::listen::{self, Listen as _, Listener};
 use all_is_cubes::math::{
-    rgba_const, Cube, Face6, FreeCoordinate, FreePoint, GridAab, GridCoordinate, GridPoint,
-    GridSize, GridVector, Rgb, Rgba, Wireframe as _, ZeroOne,
+    rgba_const, Face6, FreeCoordinate, FreePoint, GridAab, GridCoordinate, GridPoint, GridSize,
+    GridVector, Rgb, Rgba, Wireframe as _, ZeroOne,
 };
 use all_is_cubes::raycast::Ray;
 #[cfg(feature = "rerun")]
@@ -29,6 +29,7 @@ use all_is_cubes_render::{Flaws, RenderError};
 use crate::in_wgpu::block_texture::BlockTextureViews;
 use crate::in_wgpu::frame_texture::FramebufferTextures;
 use crate::in_wgpu::glue::{to_wgpu_color, to_wgpu_index_format};
+use crate::in_wgpu::light_texture::LightChunk;
 use crate::in_wgpu::pipelines::Pipelines;
 use crate::in_wgpu::skybox;
 use crate::in_wgpu::vertex::{WgpuInstanceData, WgpuLinesVertex};
@@ -1041,7 +1042,7 @@ struct SpaceRendererTodo {
     /// None means do a full space reupload.
     ///
     /// TODO: experiment with different granularities of light invalidation (chunks, dirty rects, etc.)
-    light: Option<HashSet<Cube>>,
+    light: Option<HashSet<LightChunk>>,
 
     sky: bool,
 }
@@ -1065,7 +1066,7 @@ impl listen::Store<SpaceChange> for SpaceRendererTodo {
                 SpaceChange::CubeLight { cube } => {
                     // None means we're already at "update everything"
                     if let Some(set) = &mut self.light {
-                        set.insert(cube);
+                        set.insert(LightChunk::new(cube));
                     }
                 }
                 SpaceChange::CubeBlock { .. } => {}

--- a/all-is-cubes-gpu/tests/shaders/tests.rs
+++ b/all-is-cubes-gpu/tests/shaders/tests.rs
@@ -1,7 +1,16 @@
+use std::sync::Arc;
+
+use all_is_cubes::math::GridSize;
 use all_is_cubes::raycast::scale_to_integer_step;
+use all_is_cubes::universe::Universe;
+use all_is_cubes::util::YieldProgress;
+
+use all_is_cubes_gpu::in_wgpu::{init, LightTexture};
 
 use crate::harness::run_shader_test;
 use crate::wgsl::{frag_expr, to_wgsl};
+
+// -------------------------------------------------------------------------------------------------
 
 /// Test that our test framework does what we want.
 #[tokio::test]
@@ -42,7 +51,7 @@ pub(crate) async fn modulo() {
 }
 
 #[tokio::test]
-pub(crate) async fn scale_to_integer_step_test() {
+async fn scale_to_integer_step_test() {
     for case @ (s, ds) in [(0.5f32, 0.25), (0.0, 0.25), (0.5, -0.125)] {
         dbg!(case);
         assert_eq!(
@@ -61,4 +70,94 @@ pub(crate) async fn scale_to_integer_step_test() {
             &image::Rgba([scale_to_integer_step(f64::from(s), f64::from(ds)) as f32; 4])
         );
     }
+}
+
+// -------------------------------------------------------------------------------------------------
+
+/// Not a shader test per se, but a test that the light texture updates correctly.
+#[tokio::test]
+#[rstest::rstest]
+async fn light_texture_write_read(#[values(false, true)] use_scatter: bool) {
+    use all_is_cubes::math::Rgb;
+    use all_is_cubes::space::Space;
+
+    let ((device, queue), (_universe, space, dark_space)) = tokio::join!(
+        async {
+            let instance = crate::harness::instance().await;
+            let adapter = init::create_adapter_for_test(instance).await;
+            let (device, queue) = adapter
+                .request_device(&wgpu::DeviceDescriptor::default(), None)
+                .await
+                .expect("failed to request_device");
+            let device = Arc::new(device);
+            (device, queue)
+        },
+        async {
+            let mut universe = Universe::new();
+            let space = all_is_cubes::content::testing::lighting_bench_space(
+                &mut universe,
+                YieldProgress::noop(),
+                GridSize::new(32, 32, 32),
+            )
+            .await
+            .unwrap();
+
+            // Create a second space which is identical except that it has zero light.
+            let dark_space = Space::builder(space.bounds()).sky_color(Rgb::ZERO).build();
+
+            (universe, space, dark_space)
+        }
+    );
+
+    let mut lt = LightTexture::new(
+        "light_texture_write_test",
+        &device,
+        GridSize::splat(32),
+        wgpu::TextureUsages::COPY_SRC,
+    );
+
+    if use_scatter {
+        // First initialize with black from dark_space, then refresh it using update_scatter().
+        lt.ensure_mapped(&queue, &dark_space, space.bounds());
+
+        lt.update_scatter(&device, &queue, &space, space.bounds().interior_iter());
+    } else {
+        lt.ensure_mapped(&queue, &space, space.bounds());
+    }
+
+    let texture_size = extent_to_size3d(lt.texture().size()).to_i32();
+    let light_texels: Vec<[u8; 4]> =
+        init::get_texels_from_gpu(&device, &queue, lt.texture(), 1).await;
+
+    let mut wrong_texels = Vec::new();
+    let mut count_both_zero = 0;
+    for cube in space.bounds().interior_iter() {
+        #[allow(clippy::cast_possible_wrap)]
+        let zyx_index = cube.x.rem_euclid(texture_size.width)
+            + texture_size.width
+                * (cube.y.rem_euclid(texture_size.height)
+                    + texture_size.height * cube.z.rem_euclid(texture_size.depth));
+        let expected = space.get_lighting(cube).as_texel();
+        let actual = light_texels[zyx_index as usize];
+        if expected != actual {
+            wrong_texels.push((cube, expected, actual));
+        } else if expected[0..3] == [0, 0, 0] {
+            count_both_zero += 1;
+        }
+    }
+
+    let volume = space.bounds().volume().unwrap();
+    assert_eq!(
+        wrong_texels,
+        vec![],
+        "out of {volume}, {len} were wrong and {nonzero} were not (correctly both zero)",
+        len = wrong_texels.len(),
+        nonzero = volume - count_both_zero,
+    );
+}
+
+// -------------------------------------------------------------------------------------------------
+
+fn extent_to_size3d(size: wgpu::Extent3d) -> GridSize {
+    GridSize::new(size.width, size.height, size.depth_or_array_layers)
 }

--- a/all-is-cubes/src/space/sky.rs
+++ b/all-is-cubes/src/space/sky.rs
@@ -103,8 +103,7 @@ impl BlockSky {
     /// For example, if `bounds` is from [0, 0, 0] to [5, 5, 5] and `cube` is [-1, 2, 2],
     /// then `cube` is on the -X face of `bounds`.
     ///
-    /// Panics if `cube` is not on the surface of `bounds`.
-    #[track_caller]
+    /// Returns [`PackedLight::UNINITIALIZED_AND_BLACK`] if `cube` is not on the surface of `bounds`.
     pub fn light_outside(&self, bounds: GridAab, cube: Cube) -> PackedLight {
         // Note: cube.upper_bounds() is defined to be maybe panicking, so we can't use it.
         let lower = bounds
@@ -123,7 +122,8 @@ impl BlockSky {
 
             // Cannot be inside the bounds or beyond the surface
             (false, false, false, false, false, false) => {
-                panic!("invalid cube position in BlockSky::light_outside({bounds:?}, {cube:?})");
+                // panic!("invalid cube position in BlockSky::light_outside({bounds:?}, {cube:?})");
+                PackedLight::UNINITIALIZED_AND_BLACK
             }
 
             // If it's at a corner or edge, then make it NO_RAYS, just like the block lighting


### PR DESCRIPTION
This is a workaround for <https://github.com/gfx-rs/wgpu/issues/6827>. However, it should significantly improve throughput too; copying single texels at a time is quite expensive relative to the cost of copying additional texels. I have not tuned the chunk size.