### PR TITLE
handle `Outdated` and `Lost` surface errs

### DIFF
--- a/all-is-cubes-gpu/src/in_wgpu/mod.rs
+++ b/all-is-cubes-gpu/src/in_wgpu/mod.rs
@@ -197,7 +197,7 @@ impl<I: time::Instant> SurfaceRenderer<I> {
                     ..RenderInfo::default()
                 });
             }
-            Err(e @ wgpu::SurfaceError::Outdated | e @ wgpu::SurfaceError::Lost) => {
+            Err(e @ (wgpu::SurfaceError::Outdated | wgpu::SurfaceError::Lost)) => {
                 // Reconfigure and try again next frame.
                 // NOTE: wgpu::SurfaceError::Outdated is very common with tiling window manager.
                 log::error!(


### PR DESCRIPTION
tried to run it, it panicked.
on linux `wgpu::SurfaceError::Outdated` error is common when openning/resizing window.

cool project!