### PR TITLE
Deps: Fix version mismatch of `windows`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 1.0.69",
- "windows 0.54.0",
+ "windows 0.58.0",
 ]
 
 [[package]]


### PR DESCRIPTION
`gpu-allocator` has a version range for `windows` but the dep needs to match `wgpu-hal`.