### PR TITLE
gpu,test-renderers: Explicitly enable all wgpu backends.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6479,6 +6479,7 @@ dependencies = [
  "document-features",
  "js-sys",
  "log",
+ "naga",
  "parking_lot",
  "profiling",
  "raw-window-handle",

--- a/all-is-cubes-gpu/Cargo.toml
+++ b/all-is-cubes-gpu/Cargo.toml
@@ -99,6 +99,8 @@ rstest = { workspace = true }
 scopeguard = { workspace = true }
 # Using tokio for async test-running.
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "parking_lot", "sync"] }
+# Enable wgpu backends for tests, by enabling default features.
+wgpu = { workspace = true, default-features = true }
 
 
 [lints]

--- a/test-renderers/Cargo.toml
+++ b/test-renderers/Cargo.toml
@@ -91,9 +91,9 @@ time = { workspace = true }
 tinytemplate = "1.2.1"
 # Using tokio for async test-running.
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "parking_lot", "sync", "time"] }
-# In addition to depending on wgpu directly, we also need to select backends to be enabled in our binary.
-# (As of wgpu 0.19, Vulkan is implicitly enabled on Linux.)
-wgpu = { workspace = true, features = ["dx12", "metal"] }
+# In addition to depending on wgpu directly, we also need to enable backends for the tests to
+# actually find an adapter. Enabling default features suffices (as of wgpu 24.0).
+wgpu = { workspace = true, default-features = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
In the next release of wgpu, v25, *all* backends will be controlled by features. Thus, we will want to make sure to enable all backends so that the test binaries can run tests rather than skipping them.

This change should have no effect now with wgpu v24.