### PR TITLE
Replace multiple `OnceLock` shims with `bevy_platform`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -580,13 +580,13 @@ jobs:
 
     - name: no_std lint
       run: |
-        cargo clippy --target=thumbv7em-none-eabihf --no-default-features -p all-is-cubes -p all-is-cubes-content -p all-is-cubes-render -p all-is-cubes-ui -p all-is-cubes-mesh
+        cargo clippy --target=thumbv7em-none-eabihf --no-default-features -p all-is-cubes -p all-is-cubes-content -p all-is-cubes-mesh -p all-is-cubes-render -p all-is-cubes-ui
 
     - name: no_std build
       # This is `cargo build`, not `cargo check`, because `cargo check` won't detect problems like
       # use of undefined linker symbols. Not sure if that matters.
       run: |
-        cargo build --target=thumbv7em-none-eabihf --no-default-features -p all-is-cubes -p all-is-cubes-content -p all-is-cubes-render -p all-is-cubes-ui -p all-is-cubes-mesh
+        cargo build --target=thumbv7em-none-eabihf --no-default-features -p all-is-cubes -p all-is-cubes-content -p all-is-cubes-mesh -p all-is-cubes-render -p all-is-cubes-ui
 
   fuzz:
     # Don't spend time on fuzzing if the build failed indicating the code is bad other ways

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,6 @@ dependencies = [
  "mutants 0.0.4",
  "nosy",
  "num-traits",
- "once_cell",
  "ordered-float",
  "paste",
  "png-decoder",

--- a/all-is-cubes-wasm/Cargo.lock
+++ b/all-is-cubes-wasm/Cargo.lock
@@ -36,7 +36,6 @@ dependencies = [
  "mutants 0.0.4",
  "nosy",
  "num-traits",
- "once_cell",
  "ordered-float",
  "paste",
  "png-decoder",

--- a/all-is-cubes/Cargo.toml
+++ b/all-is-cubes/Cargo.toml
@@ -63,7 +63,6 @@ std = [
     "all-is-cubes-base/std",
     "arcstr/std", # not required but nicer behavior
     "bevy_platform/std", # selects use of blocking locks instead of spinlocks
-    "once_cell/std", # used conditionally as more efficient than once_cell::race
     "nosy/std-sync", # selects use of blocking locks instead of spinlocks
     "yield-progress/sync",
 ]
@@ -146,7 +145,6 @@ manyfmt = { workspace = true }
 mutants = { workspace = true }
 nosy = { workspace = true, features = ["async", "spin-sync"] }
 num-traits = { workspace = true }
-once_cell = { workspace = true, features = ["alloc", "race"] }
 ordered-float = { workspace = true }
 paste = { workspace = true }
 png-decoder = { workspace = true }

--- a/all-is-cubes/src/content/load_image.rs
+++ b/all-is-cubes/src/content/load_image.rs
@@ -10,6 +10,7 @@ use core::fmt;
 use euclid::{Size2D, size2};
 use hashbrown::HashMap;
 
+use bevy_platform::sync::OnceLock;
 use embedded_graphics::prelude::{Point, Size};
 use embedded_graphics::primitives::Rectangle;
 use png_decoder::PngHeader;
@@ -254,7 +255,7 @@ impl core::error::Error for BlockFromImageError {
 #[derive(Debug)]
 pub struct LazyImage {
     /// Lazily decoded image data.
-    decoded_data: LazyImageInner,
+    decoded_data: OnceLock<DecodedPng>,
 
     /// PNG image data for decoding.
     encoded_data: &'static [u8],
@@ -270,7 +271,7 @@ impl LazyImage {
         encoded_data: &'static [u8],
     ) -> Self {
         Self {
-            decoded_data: LazyImageInner::new(),
+            decoded_data: OnceLock::new(),
             path,
             encoded_data,
         }
@@ -287,23 +288,15 @@ impl LazyImage {
 impl core::ops::Deref for LazyImage {
     type Target = DecodedPng;
     fn deref(&self) -> &Self::Target {
-        self.decoded_data.get_or_init(|| {
-            let decoded = match png_decoder::decode(self.encoded_data) {
-                Ok((header, data)) => DecodedPng {
-                    header,
-                    rgba_image_data: data,
-                },
-                Err(error) => panic!(
-                    "Error loading image asset {path:?}: {error:?}",
-                    path = self.path()
-                ),
-            };
-
-            // When we use OnceBox, we need to return a box.
-            #[cfg(not(feature = "std"))]
-            let decoded = ::alloc::boxed::Box::new(decoded);
-
-            decoded
+        self.decoded_data.get_or_init(|| match png_decoder::decode(self.encoded_data) {
+            Ok((header, data)) => DecodedPng {
+                header,
+                rgba_image_data: data,
+            },
+            Err(error) => panic!(
+                "Error loading image asset {path:?}: {error:?}",
+                path = self.path()
+            ),
         })
     }
 }
@@ -323,17 +316,6 @@ macro_rules! _content_load_image_include_image {
             );
         &IMAGE
     }};
-}
-
-cfg_select! {
-    feature = "std" => {
-        #[doc(hidden)]
-        type LazyImageInner = ::std::sync::OnceLock<DecodedPng>;
-    }
-    _ => {
-        #[doc(hidden)]
-        type LazyImageInner = ::once_cell::race::OnceBox<DecodedPng>;
-    }
 }
 pub use _content_load_image_include_image as include_image;
 

--- a/all-is-cubes/src/space/light/chart/mod.rs
+++ b/all-is-cubes/src/space/light/chart/mod.rs
@@ -3,6 +3,7 @@
 
 use alloc::vec::Vec;
 
+use bevy_platform::sync::OnceLock;
 use manyfmt::Refmt as _;
 
 use crate::time::Instant;
@@ -30,18 +31,8 @@ pub(crate) fn get() -> &'static [FlatNode] {
     // noticeable hang (just a lack of light updates, which are already throttled by available
     // time).
 
-    cfg_select! {
-        feature = "std" => {
-            static FLAT_TREE: std::sync::OnceLock<Vec<FlatNode>> =
-                std::sync::OnceLock::new();
-            FLAT_TREE.get_or_init(generate_chart_with_logging)
-        }
-        _ => {
-            static FLAT_TREE: once_cell::race::OnceBox<Vec<FlatNode>> =
-                once_cell::race::OnceBox::new();
-            FLAT_TREE.get_or_init(|| alloc::boxed::Box::new(generate_chart_with_logging()))
-        }
-    }
+    static FLAT_TREE: OnceLock<Vec<FlatNode>> = OnceLock::new();
+    FLAT_TREE.get_or_init(generate_chart_with_logging)
 }
 
 fn generate_chart_with_logging() -> Vec<FlatNode> {

--- a/all-is-cubes/src/universe/handle.rs
+++ b/all-is-cubes/src/universe/handle.rs
@@ -16,14 +16,15 @@ use core::sync::atomic;
 
 use bevy_ecs::prelude as ecs;
 // Note: If depending on bevy_platform becomes undesirable, then in general, a spinlock suffices;
-// this mutex is never held for a long time. We only require that it is always `Sync`.
+// the mutex is never held for a long time, and the OnceLock is never `get_or_init()`ed.
+// We only require that they are always `Sync`.
 #[cfg_attr(not(feature = "save"), allow(unused_imports))]
-use bevy_platform::sync::{Mutex, MutexGuard};
+use bevy_platform::sync::{Mutex, MutexGuard, OnceLock};
 
 use crate::universe::{
     self, AnyHandle, InsertError, InsertErrorKind, MemberBoilerplate, Membership, Name, ReadTicket,
     ReadTicketError, SealedMember, Universe, UniverseId, UniverseMember, VisitHandles,
-    id::OnceUniverseId, name::OnceName,
+    id::OnceUniverseId,
 };
 
 #[cfg(doc)]
@@ -72,7 +73,7 @@ struct Inner {
     ///
     /// This field is interior mutable and can be written only once,
     /// which happens either at construction time or when this handle is inserted into a universe.
-    permanent_name: OnceName,
+    permanent_name: OnceLock<Name>,
 
     /// Number of [`StrongHandle`]s that exist.
     strong_handle_count: atomic::AtomicUsize,
@@ -131,7 +132,10 @@ impl<T: 'static> Handle<T> {
         Handle {
             inner: Arc::new(Inner {
                 universe_id: OnceUniverseId::new(),
-                permanent_name: OnceName::from_optional_value(permanent_name),
+                permanent_name: match permanent_name {
+                    Some(n) => OnceLock::from(n),
+                    None => OnceLock::new(),
+                },
                 state: Mutex::new(state),
                 strong_handle_count: atomic::AtomicUsize::new(0),
             }),

--- a/all-is-cubes/src/universe/name.rs
+++ b/all-is-cubes/src/universe/name.rs
@@ -1,5 +1,3 @@
-#[cfg(not(feature = "std"))]
-use alloc::boxed::Box;
 use alloc::string::String;
 use core::fmt;
 
@@ -109,46 +107,6 @@ mod impl_arbitrary {
             depth: usize,
         ) -> arbitrary::Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
             ArbName::try_size_hint(depth)
-        }
-    }
-}
-
-// -------------------------------------------------------------------------------------------------
-
-pub(in crate::universe) type OnceName = MbOnceLock<Name>;
-
-/// As `std::sync::OnceLock`, but implemented using `once_cell::race::OnceBox` if necessary.
-/// Implemented generically because it might be useful for more things later.
-#[derive(Debug)]
-pub(in crate::universe) struct MbOnceLock<T>(
-    #[cfg(feature = "std")] std::sync::OnceLock<T>,
-    #[cfg(not(feature = "std"))] once_cell::race::OnceBox<T>, // OnceBox has extra boxing, so only use it if necessary
-);
-
-impl<T> MbOnceLock<T> {
-    pub fn new() -> Self {
-        Self(Default::default())
-    }
-
-    pub fn get(&self) -> Option<&T> {
-        self.0.get()
-    }
-
-    pub fn set(&self, value: T) -> Result<(), T> {
-        cfg_select! {
-            feature = "std" => self.0.set(value),
-            _ => self.0.set(Box::new(value)).map_err(|boxed| *boxed),
-        }
-    }
-
-    pub fn from_optional_value(option: Option<T>) -> Self {
-        match option {
-            Some(value) => Self(cfg_select! {
-                feature = "std" => std::sync::OnceLock::from(value),
-                _ => once_cell::race::OnceBox::with_value(Box::new(value)),
-            }),
-
-            None => Self::new(),
         }
     }
 }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -37,7 +37,6 @@ dependencies = [
  "mutants 0.0.4",
  "nosy",
  "num-traits",
- "once_cell",
  "ordered-float",
  "paste",
  "png-decoder",

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -657,6 +657,7 @@ fn do_for_all_packages(
                         .arg(op.non_build_check_subcmd())
                         .args([
                             "--package=all-is-cubes",
+                            "--package=all-is-cubes-content",
                             "--package=all-is-cubes-mesh",
                             "--package=all-is-cubes-render",
                             "--package=all-is-cubes-ui",


### PR DESCRIPTION
Benefits:

* Reduced code duplication; especially, no `cfg` code that can break the build on whichever configuration isn’t being developed.
* Replaces the race-to-initialize with a spinlock, which presumably will be more efficient (in energy consumption, scheduling, and memory usage) through spin loop hints. And, ideally we never encounter actual multithreading without the `std` feature enabled, anyway.
* No more direct dependency on `once_cell` (not that I dislike it, just, fewer dependencies).