### PR TITLE
text: Replace block text renderer with new custom code.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       # about caching the builds of them.
       # cargo-mutants and cargo-about are not used in this step but will be cached for later use.
       run: |
-        cargo install --locked wasm-pack@0.14.0 cargo-about@0.8.2 cargo-mutants@25.3.1
+        cargo install --locked wasm-pack@0.14.0 cargo-about@0.8.2 cargo-mutants@27.0.0
 
     - run: df -h .
 
@@ -526,7 +526,7 @@ jobs:
 
       # Install cargo-mutants
       # This should usually be already installed, but is present in case of cache miss
-      - run: cargo install --locked cargo-mutants@25.3.1
+      - run: cargo install --locked cargo-mutants@27.0.0
 
       - name: Relative diff
         run: |
@@ -535,7 +535,7 @@ jobs:
       
       - name: Mutants
         # See mutants.yml for notes on the package selection
-        run: cargo mutants --in-diff git.diff --package all-is-cubes -- --all-features
+        run: cargo mutants --in-diff git.diff --package=all-is-cubes --test-package=test-aic -- --all-features
 
       - uses: actions/upload-artifact@v7
         if: ${{ always() }}

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -24,11 +24,11 @@ jobs:
         run: rustup toolchain install stable --profile=minimal
 
       - name: Install cargo-mutants
-        run: cargo install --locked cargo-mutants@25.3.1
+        run: cargo install --locked cargo-mutants@27.0.0
 
       - name: Run mutation testing for all-is-cubes
         timeout-minutes: 60
-        run: cargo mutants --package all-is-cubes -- --all-features
+        run: cargo mutants --package=all-is-cubes --test-package=test-aic -- --all-features
         # TODO: Other crates' reasons for non-inclusion:
         #   all-is-cubes-content: insufficient test coverage
         #   all-is-cubes-desktop: insufficient test coverage, unclear if even feasible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 * `all-is-cubes` library:
+    * `block::Atom::from_color()`, a const fn.
     * `block::BlockDef` can now be used to make block definitions that are looping animations.
       New items `block::Animation` and `block::BlockDef::new_animated()` support this functionality.
     * `block::SetAttribute` is a modifier which overrides a single attribute of a block, instead of all of them.

--- a/all-is-cubes-content/src/city/exhibits/text_blocks.rs
+++ b/all-is-cubes-content/src/city/exhibits/text_blocks.rs
@@ -18,9 +18,12 @@ fn TEXT(_: Context<'_>) {
         offset: GridVector,
     }
 
+    let debug = true;
+
     let texts = [
         Texhibit {
             text: text::Text::builder()
+                .debug(debug)
                 .string(literal!("right back"))
                 .positioning(text::Positioning {
                     x: text::PositioningX::Right,
@@ -33,6 +36,7 @@ fn TEXT(_: Context<'_>) {
         },
         Texhibit {
             text: text::Text::builder()
+                .debug(debug)
                 .string(literal!("left front"))
                 .positioning(text::Positioning {
                     x: text::PositioningX::Left,
@@ -64,6 +68,7 @@ fn TEXT(_: Context<'_>) {
         },
         Texhibit {
             text: text::Text::builder()
+                .debug(debug)
                 .string(literal!("left back outline"))
                 .foreground(foreground_block)
                 .outline(Some(outline_block))
@@ -78,6 +83,7 @@ fn TEXT(_: Context<'_>) {
         },
         Texhibit {
             text: text::Text::builder()
+                .debug(debug)
                 .string(literal!("weird vert bounds"))
                 .layout_bounds(R16, GridAab::from_lower_upper([0, 16, 0], [64, 64, 64]))
                 // .foreground(foreground_block)

--- a/all-is-cubes/src/block.rs
+++ b/all-is-cubes/src/block.rs
@@ -880,9 +880,14 @@ impl From<Rgba> for Block {
 )]
 macro_rules! _block_from_color {
     ($color:expr) => {
-        $crate::block::Block::from_static_primitive(const {
-            &$crate::block::Primitive::from_color($color.with_alpha_one_if_has_no_alpha())
-        })
+        $crate::block::Block::from_static_primitive(
+            const {
+                // Note: We cannot use `Primitive::from_color()`
+                &$crate::block::Primitive::Atom($crate::block::Atom::from_color(
+                    $color.with_alpha_one_if_has_no_alpha(),
+                ))
+            },
+        )
     };
 
     ($r:literal, $g:literal, $b:literal $(,)?) => {
@@ -997,7 +1002,8 @@ pub const AIR: Block = Block(BlockPtr::Static(&Primitive::Air));
 impl Primitive {
     /// Construct a [`Primitive`] from a reflectance color.
     ///
-    /// This function is equivalent to `Block::from(color)` but it can be used in const contexts.
+    /// This function is equivalent to `Block::from(color)` but it can be used in const contexts
+    /// and returns a [`Primitive`] instead of a [`Block`].
     pub const fn from_color(color: Rgba) -> Primitive {
         Primitive::Atom(Atom::from_color(color))
     }
@@ -1116,9 +1122,8 @@ mod conversions_for_atom {
     impl Atom {
         /// Construct an [`Atom`] with the given reflectance color.
         ///
-        /// This is identical to `From<Rgba>::from()` except that it is a `const fn`.
-        // TODO: public API?
-        pub(crate) const fn from_color(color: Rgba) -> Self {
+        /// This function is equivalent to `Atom::from(color)` but it can be used in const contexts.
+        pub const fn from_color(color: Rgba) -> Self {
             Atom {
                 color,
                 emission: Rgb::ZERO,

--- a/all-is-cubes/src/block/tests.rs
+++ b/all-is-cubes/src/block/tests.rs
@@ -35,7 +35,7 @@ fn listen(
 }
 
 #[test]
-fn block_size_is_pointerish() {
+fn size_of_block_is_pointerish() {
     let block_size = size_of::<Block>();
     let ptr_size = size_of::<*const ()>();
     assert!(
@@ -45,10 +45,10 @@ fn block_size_is_pointerish() {
 }
 
 #[test]
-fn primitive_size() {
+fn size_of_primitive() {
     let size = size_of::<Primitive>();
     assert!(
-        size <= 96,
+        size <= 144,
         "size_of::<Primitive>() = {size} unexpectedly large"
     );
 }

--- a/all-is-cubes/src/block/text.rs
+++ b/all-is-cubes/src/block/text.rs
@@ -6,7 +6,7 @@
 )]
 
 use alloc::boxed::Box;
-use core::iter;
+use core::{fmt, iter};
 
 use arcstr::ArcStr;
 use bevy_platform::sync::OnceLock;
@@ -48,11 +48,14 @@ use super::Evoxels;
 /// To create a block or multiblock group from this, use [`Primitive::Text`].
 /// To combine the text with other shapes, use [`Modifier::Composite`].
 ///
-//--
-// TODO: Each `Text` instance should memoize glyph layout so that layout work can be shared among
-// blocks. We don't really have much to do there yet, though.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Text {
+    data: TextData,
+    // TODO: this is unused now, but will be when we replace text layout with our own
+    layout_cache: OnceLock<()>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct TextData {
     string: ArcStr,
 
     font: Font,
@@ -103,7 +106,7 @@ impl Text {
 
     /// Converts this into a [`TextBuilder`] so that it may be modified.
     pub fn into_builder(self) -> TextBuilder {
-        let Self {
+        let TextData {
             string,
             font,
             foreground,
@@ -112,7 +115,7 @@ impl Text {
             layout_bounds,
             positioning,
             debug,
-        } = self;
+        } = self.data;
         TextBuilder {
             string,
             font,
@@ -127,16 +130,16 @@ impl Text {
 
     /// Returns the string which this displays.
     pub fn string(&self) -> &ArcStr {
-        &self.string
+        &self.data.string
     }
     /// Returns the font which this uses to display the text.
     pub fn font(&self) -> &Font {
-        &self.font
+        &self.data.font
     }
 
     /// Returns the voxel resolution which the text blocks will have.
-    pub fn resolution(&self) -> &Font {
-        &self.font
+    pub fn resolution(&self) -> Resolution {
+        self.data.resolution
     }
 
     /// Returns the bounding box, within the blocks at the specified resolution, of the text.
@@ -146,17 +149,17 @@ impl Text {
     /// The text may overflow this bounding box depending on its length and the
     /// [`positioning()`](Self::positioning).
     pub fn layout_bounds(&self) -> GridAab {
-        self.layout_bounds
+        self.data.layout_bounds
     }
 
     /// Returns the [`Positioning`] parameters this uses.
     pub fn positioning(&self) -> Positioning {
-        self.positioning
+        self.data.positioning
     }
 
     /// Returns the debug-rendering flag.
     pub fn debug(&self) -> bool {
-        self.debug
+        self.data.debug
     }
 
     /// Returns the bounding box of the text as displayed, in voxels at the
@@ -169,7 +172,7 @@ impl Text {
 
         let dummy_voxel = Evoxel::from_color(Rgba::BLACK); // could be anything
         self.with_transform_and_drawable(
-            match self.outline {
+            match self.data.outline {
                 Some(_) => Brush::Outline {
                     foreground: dummy_voxel,
                     outline: dummy_voxel,
@@ -185,7 +188,7 @@ impl Text {
     ///
     /// This is identical to [`Self::bounding_voxels()`] scaled down by [`Self::resolution()`].
     pub fn bounding_blocks(&self) -> GridAab {
-        self.bounding_voxels().divide(self.resolution.into())
+        self.bounding_voxels().divide(self.resolution().into())
     }
 
     /// Returns a transaction which places [`Primitive::Text`] blocks containing this text.
@@ -251,8 +254,8 @@ impl Text {
         // Evaluate blocks making up the brush
         let brush = {
             let _recursion_scope = block::Budget::recurse(&filter.budget)?;
-            let evaluated_foreground = self.foreground.evaluate_to_evoxel_internal(filter)?;
-            match self.outline {
+            let evaluated_foreground = self.data.foreground.evaluate_to_evoxel_internal(filter)?;
+            match self.data.outline {
                 Some(ref block) => Brush::Outline {
                     foreground: evaluated_foreground,
                     outline: block.evaluate_to_evoxel_internal(filter)?,
@@ -265,34 +268,35 @@ impl Text {
             brush,
             block_offset,
             |text_obj, text_aab, drawing_transform| {
-                let voxels: Evoxels =
-                    match text_aab.intersection_cubes(GridAab::for_block(self.resolution)) {
-                        Some(bounds_in_this_block) => {
-                            let fill = if self.debug {
-                                DEBUG_TEXT_BOUNDS_VOXEL
-                            } else {
-                                Evoxel::AIR
-                            };
-                            let mut voxels: Vol<Box<[Evoxel]>> =
-                                Vol::from_fn(bounds_in_this_block, |_| fill);
-
-                            text_obj
-                                .draw(&mut DrawingPlane::new(&mut voxels, drawing_transform))
-                                .unwrap();
-
-                            Evoxels::from_many(self.resolution, voxels.map_container(Into::into))
-                        }
-
-                        None => Evoxels::from_one(if self.debug {
-                            DEBUG_NO_INTERSECTION_VOXEL
+                let voxels: Evoxels = match text_aab
+                    .intersection_cubes(GridAab::for_block(self.data.resolution))
+                {
+                    Some(bounds_in_this_block) => {
+                        let fill = if self.data.debug {
+                            DEBUG_TEXT_BOUNDS_VOXEL
                         } else {
                             Evoxel::AIR
-                        }),
-                    };
+                        };
+                        let mut voxels: Vol<Box<[Evoxel]>> =
+                            Vol::from_fn(bounds_in_this_block, |_| fill);
+
+                        text_obj
+                            .draw(&mut DrawingPlane::new(&mut voxels, drawing_transform))
+                            .unwrap();
+
+                        Evoxels::from_many(self.data.resolution, voxels.map_container(Into::into))
+                    }
+
+                    None => Evoxels::from_one(if self.data.debug {
+                        DEBUG_NO_INTERSECTION_VOXEL
+                    } else {
+                        Evoxel::AIR
+                    }),
+                };
 
                 Ok(MinEval::new(
                     BlockAttributes {
-                        display_name: self.string.clone(),
+                        display_name: self.data.string.clone(),
                         ..BlockAttributes::default()
                     },
                     voxels,
@@ -302,7 +306,7 @@ impl Text {
     }
 
     fn thickness(&self) -> GridCoordinate {
-        match self.outline {
+        match self.data.outline {
             Some(_) => 2,
             None => 1,
         }
@@ -318,14 +322,14 @@ impl Text {
             Gridgid,
         ) -> R,
     ) -> R {
-        let resolution_g = GridCoordinate::from(self.resolution);
+        let resolution_g = GridCoordinate::from(self.data.resolution);
         let Positioning {
             x: positioning_x,
             line_y,
             z: positioning_z,
-        } = self.positioning;
+        } = self.data.positioning;
 
-        let lb = self.layout_bounds;
+        let lb = self.data.layout_bounds;
         // TODO: The subtractions of 1 here are dubious.
         // I believe they are correct on the principle that embedded-graphics uses
         // "a point labels a pixel" coordinates, so even leftward-extending text
@@ -353,7 +357,7 @@ impl Text {
             Gridgid::from_translation(layout_offset - (block_offset * resolution_g))
                 * Gridgid::FLIP_Y;
 
-        let character_style = eg::mono_font::MonoTextStyle::new(self.font.eg_font(), brush);
+        let character_style = eg::mono_font::MonoTextStyle::new(self.data.font.eg_font(), brush);
         let text_style = eg::text::TextStyleBuilder::new()
             .alignment(match positioning_x {
                 PositioningX::Left => eg::text::Alignment::Left,
@@ -368,7 +372,7 @@ impl Text {
             })
             .build();
         let text_obj = &eg::text::Text::with_text_style(
-            self.string.as_str(),
+            self.data.string.as_str(),
             eg::prelude::Point::new(0, 0),
             character_style,
             text_style,
@@ -383,21 +387,90 @@ impl Text {
     }
 }
 
+impl From<TextData> for Text {
+    fn from(data: TextData) -> Self {
+        Self {
+            data,
+            layout_cache: OnceLock::new(),
+        }
+    }
+}
+
+impl Clone for Text {
+    fn clone(&self) -> Self {
+        Self {
+            data: self.data.clone(),
+            layout_cache: self.layout_cache.clone(),
+        }
+    }
+}
+
+impl PartialEq for Text {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            data,
+            layout_cache: _, // layout_cache is derived from data
+        } = self;
+        *data == other.data
+    }
+}
+impl Eq for Text {}
+
+impl core::hash::Hash for Text {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        let Self {
+            data,
+            layout_cache: _, // layout_cache is derived from data
+        } = self;
+        data.hash(state);
+    }
+}
+
 impl universe::VisitHandles for Text {
     fn visit_handles(&self, visitor: &mut dyn universe::HandleVisitor) {
         let Self {
-            string: _,
-            font,
-            foreground,
-            outline,
-            resolution: _,
-            layout_bounds: _,
-            positioning: _,
-            debug: _,
+            data:
+                TextData {
+                    string: _,
+                    font,
+                    foreground,
+                    outline,
+                    resolution: _,
+                    layout_bounds: _,
+                    positioning: _,
+                    debug: _,
+                },
+            layout_cache: _,
         } = self;
         font.visit_handles(visitor);
         foreground.visit_handles(visitor);
         outline.visit_handles(visitor);
+    }
+}
+
+#[expect(clippy::missing_fields_in_debug)]
+impl fmt::Debug for Text {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let TextData {
+            string,
+            font,
+            foreground,
+            outline,
+            resolution,
+            layout_bounds,
+            positioning,
+            debug,
+        } = &self.data;
+        f.debug_struct("Text")
+            .field("string", string)
+            .field("font", font)
+            .field("foreground", foreground)
+            .field("outline", outline)
+            .field("resolution", resolution)
+            .field("layout_bounds", layout_bounds)
+            .field("positioning", positioning)
+            .field("debug", debug)
+            .finish()
     }
 }
 
@@ -416,7 +489,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Text {
         )
         .map_err(|_volume_error| arbitrary::Error::IncorrectFormat)?;
 
-        Ok(Self {
+        Ok(Self::from(TextData {
             // ArcStr doesn't implement Arbitrary
             string: alloc::string::String::arbitrary(u)?.into(),
             font: Font::arbitrary(u)?,
@@ -426,7 +499,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Text {
             layout_bounds,
             positioning: Positioning::arbitrary(u)?,
             debug: bool::arbitrary(u)?,
-        })
+        }))
     }
 
     fn size_hint(depth: usize) -> (usize, Option<usize>) {
@@ -468,7 +541,7 @@ impl TextBuilder {
             positioning,
             debug,
         } = self;
-        Text {
+        Text::from(TextData {
             string,
             font,
             foreground,
@@ -477,7 +550,7 @@ impl TextBuilder {
             layout_bounds: layout_bounds.unwrap_or(GridAab::for_block(resolution)),
             positioning,
             debug,
-        }
+        })
     }
 
     /// Sets the string to be displayed.
@@ -792,14 +865,18 @@ mod serialization {
     impl From<&text::Text> for schema::TextSer {
         fn from(value: &text::Text) -> Self {
             let &text::Text {
-                ref string,
-                ref font,
-                ref foreground,
-                ref outline,
-                resolution,
-                layout_bounds,
-                positioning,
-                debug,
+                data:
+                    text::TextData {
+                        ref string,
+                        ref font,
+                        ref foreground,
+                        ref outline,
+                        resolution,
+                        layout_bounds,
+                        positioning,
+                        debug,
+                    },
+                layout_cache: _,
             } = value;
             schema::TextSer::TextV1 {
                 string: string.clone(),

--- a/all-is-cubes/src/block/text.rs
+++ b/all-is-cubes/src/block/text.rs
@@ -15,15 +15,12 @@ use embedded_graphics as eg;
 use embedded_graphics::mono_font::DecorationDimensions;
 use embedded_graphics::mono_font::mapping::GlyphMapping;
 use embedded_graphics::prelude::Size;
-use embedded_graphics::{Drawable as _, prelude::Dimensions as _};
-use euclid::vec3;
+use euclid::{Point2D, Size2D, point2, size2, vec2, vec3};
+use itertools::iproduct;
 
 use crate::block::{self, Block, BlockAttributes, Evoxel, MinEval, Resolution};
 use crate::content::palette;
-use crate::drawing::{DrawingPlane, rectangle_to_aab};
-use crate::math::{
-    FaceMap, GridAab, GridCoordinate, GridVector, Gridgid, Rgb, Rgba, Vol, rgba_const,
-};
+use crate::math::{GridAab, GridCoordinate, GridPoint, GridVector, Gridgid, Rgb, Vol, rgba_const};
 use crate::space::{self, SpaceTransaction};
 use crate::universe;
 
@@ -31,6 +28,11 @@ use crate::universe;
 use crate::block::{Modifier, Primitive};
 
 use super::Evoxels;
+
+// -------------------------------------------------------------------------------------------------
+
+mod layout;
+use layout::Layout;
 
 // -------------------------------------------------------------------------------------------------
 
@@ -50,8 +52,7 @@ use super::Evoxels;
 ///
 pub struct Text {
     data: TextData,
-    // TODO: this is unused now, but will be when we replace text layout with our own
-    layout_cache: OnceLock<()>,
+    layout_cache: OnceLock<Layout>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -168,20 +169,7 @@ impl Text {
     /// This box is in the same units as [`Self::layout_bounds()`] but reflects the actual text
     /// layout rather than the configuration.
     pub fn bounding_voxels(&self) -> GridAab {
-        // TODO: Memoize this “layout calculation”.
-
-        let dummy_voxel = Evoxel::from_color(Rgba::BLACK); // could be anything
-        self.with_transform_and_drawable(
-            match self.data.outline {
-                Some(_) => Brush::Outline {
-                    foreground: dummy_voxel,
-                    outline: dummy_voxel,
-                },
-                None => Brush::Plain(dummy_voxel),
-            },
-            GridVector::zero(),
-            |_text_obj, text_aab, _drawing_transform| text_aab,
-        )
+        self.get_or_init_layout().bounding_box
     }
     /// Returns the bounding box of the text, in blocks — the set of [`Primitive::Text`] offsets
     /// that will render all of it.
@@ -251,139 +239,99 @@ impl Text {
             return Ok(block::AIR_EVALUATED_MIN); // placeholder value
         }
 
-        // Evaluate blocks making up the brush
-        let brush = {
-            let _recursion_scope = block::Budget::recurse(&filter.budget)?;
-            let evaluated_foreground = self.data.foreground.evaluate_to_evoxel_internal(filter)?;
-            match self.data.outline {
-                Some(ref block) => Brush::Outline {
-                    foreground: evaluated_foreground,
-                    outline: block.evaluate_to_evoxel_internal(filter)?,
-                },
-                None => Brush::Plain(evaluated_foreground),
-            }
-        };
+        let &Layout {
+            bounding_box: text_aab,
+            ref glyphs,
+            z: layout_z,
+        } = self.get_or_init_layout();
 
-        self.with_transform_and_drawable(
-            brush,
-            block_offset,
-            |text_obj, text_aab, drawing_transform| {
-                let voxels: Evoxels = match text_aab
-                    .intersection_cubes(GridAab::for_block(self.data.resolution))
-                {
-                    Some(bounds_in_this_block) => {
-                        let fill = if self.data.debug {
-                            DEBUG_TEXT_BOUNDS_VOXEL
-                        } else {
-                            Evoxel::AIR
-                        };
-                        let mut voxels: Vol<Box<[Evoxel]>> =
-                            Vol::from_fn(bounds_in_this_block, |_| fill);
+        // Apply `block_offset` to the result of the layout.
+        // TODO: handle overflow
+        let block_offset_in_voxels = (-block_offset) * GridCoordinate::from(self.data.resolution);
+        let aab_in_block_voxel_space = text_aab.translate(block_offset_in_voxels);
 
-                        text_obj
-                            .draw(&mut DrawingPlane::new(&mut voxels, drawing_transform))
-                            .unwrap();
-
-                        Evoxels::from_many(self.data.resolution, voxels.map_container(Into::into))
+        // Check whether the text intersects the volume of this block.
+        // If it doesn’t, we can skip consulting the glyphs at all.
+        // TODO: We should also have a way to look up only the intersecting glyphs
+        // so that a fragment of a large text is handled efficiently.
+        let voxels: Evoxels = match aab_in_block_voxel_space
+            .intersection_cubes(GridAab::for_block(self.data.resolution))
+        {
+            Some(bounds_in_this_block) => {
+                // Evaluate blocks making up the brush.
+                let brush = {
+                    let _recursion_scope = block::Budget::recurse(&filter.budget)?;
+                    let evaluated_foreground =
+                        self.data.foreground.evaluate_to_evoxel_internal(filter)?;
+                    match self.data.outline {
+                        Some(ref block) => Brush::Outline {
+                            foreground: evaluated_foreground,
+                            outline: block.evaluate_to_evoxel_internal(filter)?,
+                        },
+                        None => Brush::Plain(evaluated_foreground),
                     }
-
-                    None => Evoxels::from_one(if self.data.debug {
-                        DEBUG_NO_INTERSECTION_VOXEL
-                    } else {
-                        Evoxel::AIR
-                    }),
                 };
 
-                Ok(MinEval::new(
-                    BlockAttributes {
-                        display_name: self.data.string.clone(),
-                        ..BlockAttributes::default()
-                    },
-                    voxels,
-                ))
+                let background = if self.data.debug {
+                    DEBUG_TEXT_BOUNDS_VOXEL
+                } else {
+                    Evoxel::AIR
+                };
+                let mut voxels: Vol<Box<[Evoxel]>> =
+                    Vol::from_fn(bounds_in_this_block, |_| background);
+
+                let decl = self.data.font.font_decl();
+                let pixels = decl.binary_image();
+
+                for glyph in glyphs.iter() {
+                    let glyph_position_3d: GridPoint =
+                        glyph.position.extend(layout_z).cast_unit() + block_offset_in_voxels;
+                    glyph_from_binary_image(pixels, decl, glyph.glyph_index).for_each(
+                        |position_in_glyph| {
+                            let position_in_block_of_voxel = glyph_position_3d
+                                + vec3(position_in_glyph.x, -position_in_glyph.y, 0);
+                            for (offset, evoxel) in brush.iter() {
+                                if let Some(vox) =
+                                    voxels.get_mut(position_in_block_of_voxel + offset)
+                                {
+                                    *vox = evoxel;
+                                }
+                            }
+                        },
+                    );
+                }
+
+                Evoxels::from_many(self.data.resolution, voxels.map_container(Into::into))
+            }
+
+            None => Evoxels::from_one(if self.data.debug {
+                DEBUG_NO_INTERSECTION_VOXEL
+            } else {
+                Evoxel::AIR
+            }),
+        };
+
+        Ok(MinEval::new(
+            BlockAttributes {
+                // TODO: putting the *entire* string in the name is dubious in general.
+                display_name: self.data.string.clone(),
+                ..BlockAttributes::default()
             },
-        )
+            voxels,
+        ))
     }
 
+    fn get_or_init_layout(&self) -> &Layout {
+        self.layout_cache.get_or_init(|| layout::compute_layout(&self.data))
+    }
+}
+
+impl TextData {
     fn thickness(&self) -> GridCoordinate {
-        match self.data.outline {
+        match self.outline {
             Some(_) => 2,
             None => 1,
         }
-    }
-
-    fn with_transform_and_drawable<R>(
-        &self,
-        brush: Brush,
-        block_offset: GridVector,
-        f: impl FnOnce(
-            &'_ eg::text::Text<'_, eg::mono_font::MonoTextStyle<'_, Brush>>,
-            GridAab,
-            Gridgid,
-        ) -> R,
-    ) -> R {
-        let resolution_g = GridCoordinate::from(self.data.resolution);
-        let Positioning {
-            x: positioning_x,
-            line_y,
-            z: positioning_z,
-        } = self.data.positioning;
-
-        let lb = self.data.layout_bounds;
-        // TODO: The subtractions of 1 here are dubious.
-        // I believe they are correct on the principle that embedded-graphics uses
-        // "a point labels a pixel" coordinates, so even leftward-extending text
-        // *includes* the identified pixel, but I'm not certain about that.
-        let layout_offset = vec3(
-            match positioning_x {
-                PositioningX::Left => lb.lower_bounds().x,
-                // 0.75 is a fudge factor that empirically gets the *rounding* behavior we want.
-                // though I'm still suspicious that we need to account for the text width too
-                PositioningX::Center => libm::round(lb.center().x - 0.75) as GridCoordinate,
-                PositioningX::Right => lb.upper_bounds().x - 1,
-            },
-            match line_y {
-                PositioningY::BodyBottom | PositioningY::Baseline => lb.lower_bounds().y,
-                PositioningY::BodyMiddle => libm::round(lb.center().y - 0.75) as GridCoordinate,
-                PositioningY::BodyTop => lb.upper_bounds().y - 1,
-            },
-            match positioning_z {
-                PositioningZ::Back => lb.lower_bounds().z,
-                PositioningZ::Front => lb.upper_bounds().z.saturating_sub(self.thickness()),
-            },
-        );
-
-        let drawing_transform =
-            Gridgid::from_translation(layout_offset - (block_offset * resolution_g))
-                * Gridgid::FLIP_Y;
-
-        let character_style = eg::mono_font::MonoTextStyle::new(self.data.font.eg_font(), brush);
-        let text_style = eg::text::TextStyleBuilder::new()
-            .alignment(match positioning_x {
-                PositioningX::Left => eg::text::Alignment::Left,
-                PositioningX::Center => eg::text::Alignment::Center,
-                PositioningX::Right => eg::text::Alignment::Right,
-            })
-            .baseline(match line_y {
-                PositioningY::BodyTop => eg::text::Baseline::Top,
-                PositioningY::BodyMiddle => eg::text::Baseline::Middle,
-                PositioningY::Baseline => eg::text::Baseline::Alphabetic,
-                PositioningY::BodyBottom => eg::text::Baseline::Bottom,
-            })
-            .build();
-        let text_obj = &eg::text::Text::with_text_style(
-            self.data.string.as_str(),
-            eg::prelude::Point::new(0, 0),
-            character_style,
-            text_style,
-        );
-        let text_aab = brush.expand(rectangle_to_aab(
-            text_obj.bounding_box(),
-            drawing_transform,
-            GridAab::ORIGIN_CUBE,
-        ));
-
-        f(text_obj, text_aab, drawing_transform)
     }
 }
 
@@ -698,16 +646,15 @@ pub enum Font {
 }
 
 impl Font {
-    /// Do not use. This will be removed if and when we change font renderers.
-    #[doc(hidden)]
-    pub fn eg_font(&self) -> &MonoFont<'static> {
+    /// Returns the static (compile-time constant) data for this font.
+    fn font_decl(&self) -> &'static FontDecl {
         match self {
             Self::System16 | Self::Logo => {
-                static DECL: FontDecl = FontDecl {
+                static SYSTEM16_DECL: FontDecl = FontDecl {
                     png_data: include_bytes!("text/font-system-7x16.png"),
                     png_path: "text/new-system-font.png",
                     binary_image: OnceLock::new(),
-                    character_size: Size::new(7, 16),
+                    character_size: size2(7, 16),
                     baseline: 12,
                     strikethrough: DecorationDimensions {
                         offset: 8,
@@ -718,15 +665,15 @@ impl Font {
                         height: 1,
                     },
                 };
-                static FONT: OnceLock<MonoFont<'static>> = OnceLock::new();
-                FONT.get_or_init(|| DECL.load())
+
+                &SYSTEM16_DECL
             }
             Self::SmallerBodyText => {
                 static DECL: FontDecl = FontDecl {
                     png_data: include_bytes!("text/font-body-text-6x14.png"),
                     png_path: "text/body-text-fot.png",
                     binary_image: OnceLock::new(),
-                    character_size: Size::new(6, 14),
+                    character_size: size2(6, 14),
                     baseline: 10,
                     strikethrough: DecorationDimensions {
                         offset: 7,
@@ -737,8 +684,22 @@ impl Font {
                         height: 1,
                     },
                 };
+                &DECL
+            }
+        }
+    }
+
+    /// Do not use. This will be removed when we change font renderers.
+    #[doc(hidden)]
+    pub fn eg_font(&self) -> &MonoFont<'static> {
+        match self {
+            Self::System16 | Self::Logo => {
                 static FONT: OnceLock<MonoFont<'static>> = OnceLock::new();
-                FONT.get_or_init(|| DECL.load())
+                FONT.get_or_init(|| self.font_decl().load())
+            }
+            Self::SmallerBodyText => {
+                static FONT: OnceLock<MonoFont<'static>> = OnceLock::new();
+                FONT.get_or_init(|| self.font_decl().load())
             }
         }
     }
@@ -942,23 +903,6 @@ pub(crate) enum Brush {
 // -------------------------------------------------------------------------------------------------
 
 impl Brush {
-    fn expand(&self, aab: GridAab) -> GridAab {
-        match self {
-            Brush::Plain(_) => aab,
-            Brush::Outline { .. } => aab.expand(FaceMap {
-                // TODO: This *should* expand bounds left, right, up, and down, but for now, that
-                // causes way too much trouble with positioning. As a workaround, pretend those
-                // expansions don't exist.
-                nx: 0, // should be 1
-                ny: 0, // should be 1
-                nz: 0,
-                px: 0, // should be 1
-                py: 0, // should be 1
-                pz: 1,
-            }),
-        }
-    }
-
     pub(crate) fn iter(&self) -> impl Iterator<Item = (GridVector, Evoxel)> + '_ {
         use itertools::Either::{Left, Right};
         match *self {
@@ -983,54 +927,86 @@ impl Brush {
 
 // -------------------------------------------------------------------------------------------------
 
+/// Number of glyphs which we place on each row of our .png and bitmap images.
+///
+/// TODO: Instead of this constant being used in many places, we should, when loading the font
+/// definition, reorganize it into individual glyph images. (It will also need to go away
+/// when we support non-monospaced fonts.)
+const GLYPHS_PER_ROW: u32 = 16;
+
+const GLYPHS_PER_ROW_USIZE: usize = GLYPHS_PER_ROW as usize;
+
 /// Data structure defining a font, that can go in a `static` even though we’re
 /// not using static data compatible with [`embedded_graphics::image::ImageRaw`].
+///
+/// For convenience of the implementation, glyph sizes are not allowed to exceed 255.
 struct FontDecl {
     png_data: &'static [u8],
     png_path: &'static str,
     binary_image: OnceLock<Box<[u8]>>,
-    character_size: Size,
-    baseline: u32,
+    character_size: Size2D<u8, layout::InGlyph>,
+    baseline: u8,
     strikethrough: DecorationDimensions,
     underline: DecorationDimensions,
 }
+
 impl FontDecl {
-    fn load(&'static self) -> MonoFont<'static> {
-        const GLYPHS_PER_ROW: u32 = 16;
-
-        let Self {
-            png_data,
-            png_path,
-            ref binary_image,
-            character_size,
-            baseline,
-            strikethrough,
-            underline,
-        } = *self;
-
-        let binary_image = binary_image.get_or_init(|| {
+    /// Ensures the 1bpp packed font bitmap is loaded (decoding the PNG if needed)
+    /// and returns a reference to it.
+    fn binary_image(&'static self) -> &'static [u8] {
+        self.binary_image.get_or_init(|| {
             let decoded_png =
-                crate::content::load_image::DecodedPng::decode_static(png_data, png_path);
+                crate::content::load_image::DecodedPng::decode_static(self.png_data, self.png_path);
             assert_eq!(
                 decoded_png.size().width,
-                character_size.width * GLYPHS_PER_ROW
+                u32::from(self.character_size.width) * GLYPHS_PER_ROW
             );
             pack_into_binary_color_image_data(decoded_png.pixels())
-        });
+        })
+    }
 
+    fn load(&'static self) -> MonoFont<'static> {
         MonoFont {
             glyph_mapping: &RemapTo8859_1(&embedded_graphics::mono_font::mapping::ISO_8859_1),
             image: embedded_graphics::image::ImageRaw::new(
-                binary_image,
-                self.character_size.width * GLYPHS_PER_ROW,
+                self.binary_image(),
+                u32::from(self.character_size.width) * GLYPHS_PER_ROW,
             ),
-            character_size,
+            character_size: Size {
+                width: self.character_size.width.into(),
+                height: self.character_size.height.into(),
+            },
             character_spacing: 0,
-            baseline,
-            strikethrough,
-            underline,
+            baseline: self.baseline.into(),
+            strikethrough: self.strikethrough,
+            underline: self.underline,
         }
     }
+}
+
+/// Given [`FontDecl::binary_image()`] data, iterate over all the pixels making up one glyph.
+///
+/// TODO: the results of this should typed, not as points, but as unit squares like `Cube`
+/// is a unit cube (or literally `Cube` if we choose to denote voxels this early).
+fn glyph_from_binary_image(
+    pixels: &[u8],
+    decl: &FontDecl,
+    glyph_index: usize,
+) -> impl Iterator<Item = Point2D<GridCoordinate, layout::InGlyph>> {
+    let image_width = usize::from(decl.character_size.width) * GLYPHS_PER_ROW_USIZE;
+    let glyph_origin = vec2(
+        glyph_index % GLYPHS_PER_ROW_USIZE * decl.character_size.width as usize,
+        glyph_index / GLYPHS_PER_ROW_USIZE * decl.character_size.height as usize,
+    );
+    iproduct!(0..decl.character_size.height, 0..decl.character_size.width)
+        .map(move |(y, x)| point2(GridCoordinate::from(x), GridCoordinate::from(y)))
+        .filter(move |&position_in_glyph| {
+            let pixel = position_in_glyph.to_usize() + glyph_origin;
+            let bit_index = pixel.y * image_width + pixel.x;
+            let byte_index = bit_index / 8;
+            let bit_pos = 7 - (bit_index % 8); // MSB-first packing
+            pixels.get(byte_index).is_some_and(|&b| b & (1 << bit_pos) != 0)
+        })
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/all-is-cubes/src/block/text/README.md
+++ b/all-is-cubes/src/block/text/README.md
@@ -1,4 +1,4 @@
-These fonts were created by Kevin Reid for All is Cubes.
+The fonts contained in the `png` files in this directory were created by Kevin Reid for All is Cubes.
 
 Some inspiration was drawn from the fonts of [`embedded-graphics`],
 and the Apple IIGS system font “Shaston”.

--- a/all-is-cubes/src/block/text/layout.rs
+++ b/all-is-cubes/src/block/text/layout.rs
@@ -1,0 +1,237 @@
+//! Text layout and glyph selection algorithm.
+
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+use euclid::{Point2D, point2, vec2, vec3};
+
+use crate::block::text;
+use crate::math::{GridAab, GridCoordinate};
+
+// -------------------------------------------------------------------------------------------------
+
+/// The result of text layout: a list of glyphs to draw in specific positions.
+///
+/// Must be used with the [`text::Font`] it was created with.
+//---
+// TODO: consider making this a slice-tailed `Arc<Layout>` to reduce the size of `Text` and
+// `Primitive` (will need <https://docs.rs/slice-dst/>).
+#[derive(Clone, Debug)]
+pub(crate) struct Layout {
+    /// Bounding box of all glyphs to be drawn according to this layout.
+    ///
+    /// This is not necessarily contained by the [`text::Text::layout_bounds`].
+    /// It is also not necessarily equal to the logical size of the text;
+    /// for example, if the text starts or ends with blank lines,
+    /// this box will not contain the height of those blank lines.
+    /// This box is intended solely to answer the *rendering* question of what region of space is
+    /// affected by drawing this text.
+    pub bounding_box: GridAab,
+
+    /// Z-axis translation of the glyphs when they are drawn.
+    /// Not part of `PositionedGlyph::position` since it is (currently) the same for all.
+    pub z: GridCoordinate,
+
+    /// Glyphs to draw.
+    pub glyphs: Arc<[PositionedGlyph]>,
+}
+
+/// A single positioned glyph making up part of a text [`Layout`].
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PositionedGlyph {
+    /// Index into the font's glyph table (ISO-8859-1 minus 0x20).
+    ///
+    /// TODO: optimize using smaller index type.
+    /// We could probably get away with using u16.
+    pub glyph_index: usize,
+
+    /// Position, in X-right Y-up coordinates (same as `Evoxels` coordinates),
+    /// relative to (TODO: explain), of the top-left corner of this glyph.
+    ///
+    /// TODO: once we have an explanation, define a proper coordinate system type.
+    pub position: Point2D<GridCoordinate, ()>,
+}
+
+/// [`euclid`] coordinate system type for coordinates within a single glyph image.
+///
+/// X increases rightward and Y increases downward.
+/// There is no Z.
+/// The origin is the top-left corner of the glyph image.
+pub(crate) struct InGlyph;
+
+// -------------------------------------------------------------------------------------------------
+
+/// For a given piece of text, computes what glyphs to actually draw at what positions.
+pub(crate) fn compute_layout(text: &text::TextData) -> Layout {
+    let decl = text.font.font_decl();
+    let character_size_g = decl.character_size.to_i32();
+    let z_expansion: GridCoordinate = text.outline.is_some().into();
+
+    // Find the *point* within the layout_bounds the text is positioned relative to.
+    //
+    // TODO: The subtractions of 1 here are based on a bad foundation, namely that coordinates
+    // identify pixels (not boundaries), so even leftward-extending text *includes* the
+    // identified pixel. We should stop doing that and stick to boundaries.
+    //
+    // TODO: Given that both text width and layout bounds may be odd or even, it is not sufficient
+    // for this to be an integer point; it needs to be possibly half-integer (0, 0.5, 1, 1.5, ...).
+    let lb = text.layout_bounds;
+    let layout_offset = vec3(
+        match text.positioning.x {
+            text::PositioningX::Left => lb.lower_bounds().x,
+            // 0.75 is a fudge factor that empirically gets the *rounding* behavior we want.
+            text::PositioningX::Center => libm::round(lb.center().x - 0.75) as GridCoordinate,
+            text::PositioningX::Right => lb.upper_bounds().x - 1,
+        },
+        match text.positioning.line_y {
+            text::PositioningY::BodyTop => lb.upper_bounds().y - 1,
+            text::PositioningY::BodyMiddle => {
+                // 0.75 is fudge factor to get rounding right — TODO: see if this cancels out another off by 1
+                libm::round(lb.center().y - 0.75) as GridCoordinate
+                    + (character_size_g.height - 1) / 2
+            }
+            text::PositioningY::Baseline => {
+                lb.lower_bounds().y + GridCoordinate::from(decl.baseline)
+            }
+            text::PositioningY::BodyBottom => lb.lower_bounds().y + character_size_g.height - 1,
+        },
+        match text.positioning.z {
+            text::PositioningZ::Back => lb.lower_bounds().z,
+            text::PositioningZ::Front => lb.upper_bounds().z.saturating_sub(text.thickness()),
+        },
+    );
+
+    let mut glyphs: Vec<PositionedGlyph> = Vec::new();
+    let mut bounding_box: Option<GridAab> = None;
+    // Y coordinate of the position of the glyphs of the next line, relative to the origin of the
+    // glyphs of the first line. Accumulates the height of the text.
+    let mut cursor_y: GridCoordinate = 0;
+
+    // TODO: Eventually we will likely want to switch to treating line break characters more like
+    // a command (inside a single loop over graphemes) than like a separator of lines.
+    for line in text.string.split('\n') {
+        // Index in `glyphs` of the first glyph of this line.
+        // Once we know the line length, this will let us adjust the horizontal positioning
+        let first_glyph_of_line = glyphs.len();
+
+        // Accumulates the length of this line of text by summing glyph sizes.
+        let mut cursor_x: GridCoordinate = 0;
+
+        // TODO: chars() is not the correct tool; we should be splitting on grapheme clusters
+        // and mapping those to glyphs.
+        for c in line.chars() {
+            let glyph_index = char_to_glyph_index(c);
+            let position: Point2D<GridCoordinate, ()> =
+                point2(cursor_x, cursor_y) + layout_offset.xy();
+
+            // TODO: we should use tight bounding boxes around each glyph, so the text bounding box
+            // is tight, but we currently don't have those to start with.
+
+            // Advance cursor to the right edge of the glyph.
+            // This will become more complex when we have proportional fonts and kerning.
+            cursor_x += character_size_g.width;
+
+            glyphs.push(PositionedGlyph {
+                glyph_index,
+                position,
+            });
+        }
+
+        // Now that we know the width of the line, we can figure out where it should be positioned
+        // horizontally.
+        let line_width = cursor_x; // when fonts get fancier these may be different
+        let line_start_x: GridCoordinate = match text.positioning.x {
+            text::PositioningX::Left => 0,
+            text::PositioningX::Center => -(line_width - 1) / 2,
+            text::PositioningX::Right => -(line_width - 1),
+        };
+
+        // Move all glyphs in the line to where they should be,
+        // and add them to the overall bounding box.
+        for glyph in &mut glyphs[first_glyph_of_line..] {
+            glyph.position.x = glyph.position.x.saturating_add(line_start_x);
+
+            // TODO: neither this nor the consistency check accounts for outline expansion in x and y
+            let glyph_bounding_box = GridAab::from_lower_upper(
+                // accounting for Y flip -- TODO: load fonts Y-up instead
+                (glyph.position + vec2(0, 1 - character_size_g.height))
+                    .extend(layout_offset.z)
+                    .cast_unit(),
+                (glyph.position + vec2(character_size_g.width, 1))
+                    .extend(layout_offset.z + 1 + z_expansion)
+                    .cast_unit(),
+            );
+            bounding_box = Some(match bounding_box {
+                None => glyph_bounding_box,
+                Some(bb) => bb.union_cubes(glyph_bounding_box),
+            });
+        }
+
+        // Move cursor to the next line.
+        cursor_y -= character_size_g.height;
+    }
+
+    let result = Layout {
+        bounding_box: bounding_box.unwrap_or(GridAab::ORIGIN_EMPTY),
+        glyphs: Arc::from(glyphs),
+        z: layout_offset.z,
+    };
+
+    #[cfg(debug_assertions)]
+    result.consistency_check(decl);
+
+    result
+}
+
+// -------------------------------------------------------------------------------------------------
+
+impl Layout {
+    #[cfg(debug_assertions)]
+    pub(crate) fn consistency_check(&self, font: &text::FontDecl) {
+        // TODO: neither this nor the original computation accounts for outlines
+        let bounding_box_from_glyphs =
+            euclid::Box2D::from_points(self.glyphs.iter().flat_map(|glyph| {
+                [
+                    glyph.position + vec2(0, 1), // account for Y flip -- TODO: load fonts Y-up instead
+                    glyph.position
+                        + vec2(
+                            GridCoordinate::from(font.character_size.width),
+                            1 - GridCoordinate::from(font.character_size.height),
+                        ),
+                ]
+            }));
+
+        if bounding_box_from_glyphs.is_empty() {
+            assert!(self.bounding_box.is_empty());
+        } else {
+            // TODO: check Z axis too
+            assert_eq!(
+                euclid::Box2D::new(
+                    self.bounding_box.lower_bounds().xy(),
+                    self.bounding_box.upper_bounds().xy(),
+                )
+                .cast_unit(),
+                bounding_box_from_glyphs
+            );
+        }
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+
+/// Convert a Unicode character to a glyph index.
+///
+/// This is a placeholder for fonts eventually having their own glyph tables.
+fn char_to_glyph_index(c: char) -> usize {
+    // Remap characters for which we use the same glyphs
+    let c = match c {
+        '\u{2018}' | '\u{2019}' => '\'',
+        '\u{201C}' | '\u{201D}' => '"',
+        c => c,
+    };
+    match c {
+        '\u{20}'..='\u{7F}' => (c as usize) - 0x20,
+        '\u{80}'..='\u{FF}' => (c as usize) - 0x40,
+        _ => 0x1f, // unavailable glyphs become question marks -- TODO: dedicate a glyph
+    }
+}


### PR DESCRIPTION
This is a step towards having our own complete text rendering system, voxel-aware and customizable to our needs, and dropping the dependency on the `embedded-graphics` library (per #528).

Future work:
* We still use `embedded-graphics` for text that does not appear in blocks. We will need to add an alternate entry point to the new text renderer, which allows rendering a piece of text to an image that isn’t a block evaluation.
* We still use `embedded-graphics` types for `DrawableTexture`. Hopefully, it will be possible to replace those types with our own points and colors without too much disruption.
* Once `embedded-graphics` is no longer touching the font data, we can start handling it differently, such as storing it Y-up instead of Y-down, and adding new features.
* Remove the range restriction on fuzzing `Text` values, now that it’s within our power to handle numeric overflow.
* Add tests for the behavior of the text layout algorithm — as direct tests of the glyph boxes it produces rather than image comparisons, so that they can be cheap and thorough. (Filed #776)