### PR TITLE
universe: Add builtin handles, `BuiltinName`, and `Name::Builtin`.

### DIFF
--- a/all-is-cubes-port/src/export.rs
+++ b/all-is-cubes-port/src/export.rs
@@ -166,6 +166,8 @@ impl ExportSet {
     /// TODO: This is incompatible with the "extract" approach to handling what to export.
     /// Fix that by separately tracking whether the set *started* with multiple items
     /// that need suffixing.
+    ///
+    /// TODO: Needs to sanitize names and ensure there are no overlaps.
     #[cfg_attr(not(feature = "stl"), allow(dead_code))]
     pub(crate) fn member_export_path(
         &self,
@@ -182,6 +184,8 @@ impl ExportSet {
                 universe::Name::Specific(s) => new_file_name.push(&*s),
                 universe::Name::Anonym(n) => new_file_name.push(n.to_string()),
                 universe::Name::Pending => todo!(),
+                // TODO: it is possible that a `Builtin` will conflict with a `Specific`
+                universe::Name::Builtin(b) => new_file_name.push(b.to_string()),
             }
             new_file_name.push(".");
             new_file_name.push(base_path.extension().expect("extension missing"));

--- a/all-is-cubes/src/save/conversion.rs
+++ b/all-is-cubes/src/save/conversion.rs
@@ -1297,19 +1297,29 @@ mod universe {
 
     impl<'de, T: universe::UniverseMember + 'static> Deserialize<'de> for Handle<T> {
         fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-            match HandleSer::deserialize(deserializer)? {
-                HandleSer::HandleV1 { name } => {
-                    match tl::get_from_context(tl::Purpose::Deserialization, {
-                        let name = name.clone();
-                        |context| context.universe.get_or_insert_deserializing(name)
-                    }) {
-                        Some(result) => result.map_err(serde::de::Error::custom),
-                        None => {
+            let name = match HandleSer::deserialize(deserializer)? {
+                HandleSer::HandleV1 { name } => name,
+            };
+
+            match tl::get_from_context(tl::Purpose::Deserialization, {
+                let name = name.clone();
+                |context| context.universe.get_or_insert_deserializing(name)
+            }) {
+                Some(result) => result.map_err(serde::de::Error::custom),
+                None => {
+                    match name {
+                        Name::Specific(_) | Name::Anonym(_) => {
                             // If there is no `Universe` context, use a “gone” handle.
                             // I am unsure whether this has any practical application, but it
                             // is at least useful in deserialization tests.
                             Ok(Handle::new_gone(name))
                         }
+                        Name::Builtin(builtin) => Ok(builtin.handle().clone()),
+                        Name::Pending => Err(serde::de::Error::custom(
+                            "cannot deserialize a pending Handle, \
+                                    because they would have lost their association \
+                                    with their originating transaction",
+                        )),
                     }
                 }
             }
@@ -1326,6 +1336,7 @@ mod universe {
                         "cannot serialize a pending Handle",
                     ));
                 }
+                &Name::Builtin(name) => NameSer::Builtin(name),
             }
             .serialize(serializer)
         }
@@ -1336,6 +1347,7 @@ mod universe {
             Ok(match NameSer::deserialize(deserializer)? {
                 NameSer::Specific(s) => Name::Specific(s),
                 NameSer::Anonym(n) => Name::Anonym(n),
+                NameSer::Builtin(b) => Name::Builtin(b),
             })
         }
     }
@@ -1351,6 +1363,22 @@ mod universe {
         {
             let &schema::SerializeHandle(read_ticket, ref handle) = self;
             read_handle_for_serialization(read_ticket, handle)?.serialize(serializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for universe::Builtin {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            let string = <Cow<'de, str> as Deserialize<'de>>::deserialize(deserializer)?;
+            string.parse::<Self>().map_err(serde::de::Error::custom)
+        }
+    }
+
+    impl Serialize for universe::Builtin {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            self.static_string().serialize(serializer)
         }
     }
 

--- a/all-is-cubes/src/save/schema.rs
+++ b/all-is-cubes/src/save/schema.rs
@@ -609,6 +609,7 @@ pub(crate) enum HandleSer {
 pub(crate) enum NameSer {
     Specific(ArcStr),
     Anonym(usize),
+    Builtin(universe::Builtin),
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/all-is-cubes/src/save/tests.rs
+++ b/all-is-cubes/src/save/tests.rs
@@ -29,7 +29,7 @@ use crate::tag;
 use crate::text;
 use crate::time;
 use crate::transaction::Transaction as _;
-use crate::universe::{Handle, Name, PartialUniverse, ReadTicket, Universe};
+use crate::universe::{self, Builtin, Handle, Name, PartialUniverse, ReadTicket, Universe};
 
 #[track_caller]
 /// Serialize and deserialize and assert the value is equal.
@@ -883,6 +883,7 @@ fn universe_with_one_of_each() -> Box<Universe> {
         .read_ticket(universe.read_ticket())
         .build_and_mutate(|m| {
             m.set([0, 0, 0], Block::from(block_handle))?;
+            m.set([0, 0, 1], Block::from(Builtin::Air.handle().clone()))?;
             Ok(())
         })
         .unwrap();
@@ -1019,10 +1020,17 @@ fn universe_with_one_of_each_json() -> serde_json::Value {
                                 "type": "IndirectV1",
                                 "definition": {"type": "HandleV1", "Specific": "a_block"},
                             }
+                        },
+                        {
+                            "type": "BlockV1",
+                            "primitive": {
+                                "type": "IndirectV1",
+                                "definition": {"type": "HandleV1", "Builtin": "air"},
+                            }
                         }
                     ],
                     "contents": space_contents_json([
-                        1, 0, 0, 0, //
+                        1, 2, 0, 0, //
                         0, 0, 0, 0,
                     ]),
                     "light": null,
@@ -1151,6 +1159,10 @@ fn universe_de_error_in_member() {
     );
 }
 
+// Note: These deserialization tests exercise the path for `Handle`s *not* tied to a universe,
+// which will be either builtin or in state `Gone`.
+// Handles in a universe are exercised by tests like [`universe_success()`].
+
 #[test]
 fn handle_de_named() {
     let r: Handle<BlockDef> = from_value(json!({
@@ -1158,7 +1170,12 @@ fn handle_de_named() {
         "Specific": "foo",
     }))
     .unwrap();
+
     assert_eq!(r.name(), Name::Specific("foo".into()));
+    assert_eq!(
+        r.read(ReadTicket::stub()).unwrap_err().gone(),
+        Some(universe::GoneReason::CreatedGone {})
+    );
 }
 
 #[test]
@@ -1168,7 +1185,25 @@ fn handle_de_anon() {
         "Anonym": 5,
     }))
     .unwrap();
+
     assert_eq!(r.name(), Name::Anonym(5));
+    assert_eq!(
+        r.read(ReadTicket::stub()).unwrap_err().gone(),
+        Some(universe::GoneReason::CreatedGone {})
+    );
+}
+
+#[test]
+fn handle_de_builtin() {
+    let handle: Handle<BlockDef> = from_value(json!({
+        "type": "HandleV1",
+        "Builtin": "air",
+    }))
+    .unwrap();
+
+    assert_eq!(handle, *Builtin::Air.handle());
+    // Unlike other handles, we can actually exercise these even without a universe!
+    assert_eq!(handle.read(ReadTicket::stub()).unwrap().block(), &AIR);
 }
 
 #[test]
@@ -1189,6 +1224,17 @@ fn handle_ser_anon() {
         json!({
             "type": "HandleV1",
             "Anonym": 5,
+        })
+    );
+}
+
+#[test]
+fn handle_ser_builtin() {
+    assert_eq!(
+        to_value(Builtin::Air.handle::<BlockDef>()).unwrap(),
+        json!({
+            "type": "HandleV1",
+            "Builtin": "air",
         })
     );
 }

--- a/all-is-cubes/src/tag.rs
+++ b/all-is-cubes/src/tag.rs
@@ -11,6 +11,9 @@ use crate::universe::Universe;
 /// Identifies game entities of a certain game-mechanical kind.
 ///
 /// For example, blocks that can be destroyed with a particular tool.
+//---
+// TODO: Now that we have builtin handles, replace this enum with just `Handle<TagDef>`,
+// unless we want parameterized tags.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]

--- a/all-is-cubes/src/text/font.rs
+++ b/all-is-cubes/src/text/font.rs
@@ -17,6 +17,8 @@ use crate::block::Text;
 // -------------------------------------------------------------------------------------------------
 
 /// A font that may be used with [`Text`] blocks.
+//---
+// TODO: Now that we have builtin handles, replace this enum with just `Handle<FontDef>`.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]

--- a/all-is-cubes/src/universe.rs
+++ b/all-is-cubes/src/universe.rs
@@ -37,6 +37,9 @@ pub(crate) use members::*;
 )]
 pub use members::{AnyHandle, Type, UniverseMember};
 
+mod builtin;
+pub use builtin::{Builtin, UnknownBuiltin};
+
 mod ecs_details;
 use ecs_details::NameMap;
 pub use ecs_details::PubliclyMutableComponent;
@@ -239,12 +242,39 @@ impl Universe {
         )
     }
 
+    /// Translates a name for an object of type `T` into a [`Handle`] for it.
+    ///
+    /// Returns [`None`] if no object exists for the name or if its type is not `T`.
+    //---
+    // TODO: consider changing this to return a `Result` — but we need a suitable error type;
+    // `TypeError` can’t handle “missing”.
+    pub fn get<T>(&self, name: &Name) -> Option<Handle<T>>
+    where
+        T: UniverseMember,
+    {
+        self.get_any(name)?.try_into().ok()
+    }
+
     /// Returns a [`Handle`] for the object in this universe with the given name,
     /// regardless of its type, or [`None`] if there is none.
     ///
     /// This is a dynamically-typed version of [`Universe::get()`].
-    pub fn get_any(&self, name: &Name) -> Option<&AnyHandle> {
-        self.world.resource::<NameMap>().map.get(name)
+    pub fn get_any(&self, name: &Name) -> Option<&dyn ErasedHandle> {
+        match *name {
+            // Normal case.
+            Name::Specific(_) | Name::Anonym(_) => self
+                .world
+                .resource::<NameMap>()
+                .map
+                .get(name)
+                .map(|ah: &AnyHandle| -> &dyn ErasedHandle { &**ah }),
+
+            // Builtins are treated as if they exist in every universe.
+            Name::Builtin(builtin) => Some(builtin.erased_handle()),
+
+            // Can never succeed, so don’t bother trying.
+            Name::Pending => None,
+        }
     }
 
     /// Returns the character named `"character"`.
@@ -415,22 +445,6 @@ impl Universe {
             .expect("shouldn't happen: insert_anonymous failed")
     }
 
-    /// Translates a name for an object of type `T` into a [`Handle`] for it.
-    ///
-    /// Returns [`None`] if no object exists for the name or if its type is not `T`.
-    //---
-    // TODO: consider changing this to return a `Result` — but we need a suitable error type;
-    // `TypeError` can’t handle “missing”.
-    pub fn get<T>(&self, name: &Name) -> Option<Handle<T>>
-    where
-        T: UniverseMember,
-    {
-        match self.world.resource::<NameMap>().map.get(name) {
-            Some(handle) => AnyHandle::downcast_ref(handle).ok().cloned(),
-            None => None,
-        }
-    }
-
     /// Inserts a new object with a specific name.
     ///
     /// # Errors
@@ -457,18 +471,18 @@ impl Universe {
         T: UniverseMember,
     {
         match name {
-            Name::Pending => {
-                return Err(DeserializeHandlesError {
-                    name,
-                    kind: DeserializeHandlesErrorKind::InvalidName,
-                });
+            Name::Specific(_) | Name::Anonym(_) => {
+                if let Some(handle) = self.get(&name) {
+                    Ok(handle)
+                } else {
+                    Ok(Handle::new_deserializing(name, self))
+                }
             }
-            Name::Specific(_) | Name::Anonym(_) => {}
-        }
-        if let Some(handle) = self.get(&name) {
-            Ok(handle)
-        } else {
-            Ok(Handle::new_deserializing(name, self))
+            Name::Builtin(builtin) => Ok(builtin.handle().clone()),
+            Name::Pending => Err(DeserializeHandlesError {
+                name,
+                kind: DeserializeHandlesErrorKind::InvalidName,
+            }),
         }
     }
 
@@ -556,7 +570,7 @@ impl Universe {
                 }
                 Ok(proposed_name.clone())
             }
-            Name::Anonym(_) => Err(InsertError {
+            Name::Anonym(_) | Name::Builtin(_) => Err(InsertError {
                 name: proposed_name.clone(),
                 kind: InsertErrorKind::InvalidName,
             }),
@@ -583,7 +597,7 @@ impl Universe {
             return false;
         };
         let entity = handle.as_entity(self.id).unwrap();
-        handle.set_state_to_gone(GoneReason::Deleted {});
+        handle.to_any_handle().set_state_to_gone(GoneReason::Deleted {});
         let success = self.world.despawn(entity);
         assert!(success);
         true

--- a/all-is-cubes/src/universe/builtin.rs
+++ b/all-is-cubes/src/universe/builtin.rs
@@ -1,0 +1,231 @@
+use alloc::boxed::Box;
+use alloc::string::String;
+use core::fmt;
+
+use bevy_platform::sync::LazyLock;
+
+use crate::block::{self, BlockDef};
+use crate::universe::{self, AnyPending, Handle, ReadTicket};
+
+// -------------------------------------------------------------------------------------------------
+
+macro_rules! derive_for_builtin_name {
+    (
+        $(#[$ignored_attr:meta])*
+        pub enum Builtin {
+            $(
+                $( #[doc $($doc:tt)*] )*
+                #[custom(
+                    string = $string:literal,
+                    value: $member_ty:ident = $value_expr:expr,
+                )]
+                $variant:ident,
+            )*
+        }
+    ) => {
+
+        impl Builtin {
+            // Used for serialization.
+            // If we decide to make this public, it should be `Into<&'static str>` and `AsRef<str>`.
+            #[cfg_attr(not(feature = "save"), allow(dead_code))]
+            pub(crate) fn static_string(self) -> &'static str {
+                match self {
+                    $( Self::$variant => $string, )*
+                }
+            }
+
+            /// Obtains the type-erased handle and value for this builtin,
+            /// initializing them if not already done.
+            pub(in crate::universe) fn get(self) -> &'static AnyPending {
+                match self {
+                    $( Self::$variant => {
+                        // TODO: `AnyPending` is not ideal here because it has the `Option`ality.
+                        // Also, we could store this in a non-type-erased form.
+                        static DATA: LazyLock<AnyPending> = LazyLock::new(|| {
+                            AnyPending::$member_ty {
+                                handle: Handle::new_for_builtin_initialization(Builtin::$variant),
+                                value: Some(Box::new($value_expr)),
+                            }
+                        });
+                        &*DATA
+                    } )*
+                }
+            }
+        }
+
+        impl fmt::Display for Builtin {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.pad(match *self {
+                    $(
+                        Self::$variant => $string,
+                    )*
+                })
+            }
+        }
+
+        impl core::str::FromStr for Builtin {
+            type Err = UnknownBuiltin;
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                match s {
+                    $(
+                        $string => Ok(Self::$variant),
+                    )*
+                    _ => Err(UnknownBuiltin(String::from(s))),
+                }
+            }
+        }
+
+    }
+}
+
+#[macro_rules_attribute::derive(derive_for_builtin_name!)]
+/// Name of an immutable object defined by All is Cubes.
+///
+/// [`Handle`]s to builtins act as if they exist in all universes.
+/// To obtain such a handle, call [`Builtin::handle()`].
+#[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd, exhaust::Exhaust)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
+pub enum Builtin {
+    /// A copy of `Primitive::Air`.
+    ///
+    /// This hidden variant exists to prototype the builtins system.
+    /// One of the following should occur:
+    ///
+    /// * Replace this with other, more valuable builtins.
+    /// * `Primitive::Air` should be entirely replaced by a `Primitive::Indirect` builtin
+    ///   pointing to a `Primitive::Atom`.
+    /// * Delete the builtins system.
+    #[doc(hidden)]
+    #[custom(
+        string = "air",
+        value: BlockDef = BlockDef::new(ReadTicket::stub(), block::AIR),
+    )]
+    Air,
+}
+
+impl Builtin {
+    /// Returns the [`Handle`] to this builtin, assuming that it is of type `Handle<T>`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the builtin’s type is not `T`.
+    pub fn handle<T: universe::UniverseMember>(self) -> &'static Handle<T> {
+        self.erased_handle()
+            .try_into()
+            .unwrap_or_else(|error| panic!("type mismatch in Builtin::handle(): {error}"))
+    }
+
+    /// Returns the type-erased [`Handle`] to this builtin.
+    pub fn erased_handle(self) -> &'static dyn universe::ErasedHandle {
+        self.get().handle()
+    }
+}
+
+impl<T: universe::UniverseMember> TryFrom<Builtin> for &'static Handle<T> {
+    type Error = universe::TypeError;
+
+    fn try_from(builtin: Builtin) -> Result<Self, Self::Error> {
+        builtin.erased_handle().try_into()
+    }
+}
+
+impl<T: universe::UniverseMember> TryFrom<Builtin> for Handle<T> {
+    type Error = universe::TypeError;
+
+    fn try_from(builtin: Builtin) -> Result<Self, Self::Error> {
+        builtin.erased_handle().try_into()
+    }
+}
+
+impl From<Builtin> for universe::AnyHandle {
+    fn from(builtin: Builtin) -> Self {
+        builtin.erased_handle().into()
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+
+/// Error from parsing a string as a [`Builtin`].
+#[derive(Clone, Debug, PartialEq)]
+#[allow(clippy::exhaustive_structs)]
+pub struct UnknownBuiltin(pub String);
+
+impl fmt::Display for UnknownBuiltin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown builtin '{}'", self.0)
+    }
+}
+
+impl core::error::Error for UnknownBuiltin {}
+
+// -------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString as _;
+    use exhaust::Exhaust as _;
+
+    #[test]
+    fn basic_usage() {
+        let handle: &Handle<BlockDef> = Builtin::Air.handle();
+        assert_eq!(
+            *handle.read(ReadTicket::stub()).unwrap().block(),
+            block::AIR
+        );
+    }
+
+    #[test]
+    #[should_panic = "type mismatch in Builtin::handle(): expected Space, but found BlockDef builtin 'air'"]
+    fn wrong_static_type() {
+        _ = Builtin::Air.handle::<crate::space::Space>();
+    }
+
+    #[test]
+    fn handle_equality() {
+        assert_eq!(
+            Builtin::Air.handle::<BlockDef>(),
+            Builtin::Air.erased_handle(),
+        );
+        assert_eq!(
+            Builtin::Air.handle::<BlockDef>(),
+            Builtin::Air.handle::<BlockDef>(),
+        );
+    }
+
+    #[test]
+    fn string_conversions() {
+        let name = Builtin::Air;
+        let string = "air";
+
+        assert_eq!(name.static_string(), string);
+        assert_eq!(name.to_string(), string);
+        assert_eq!(string.parse::<Builtin>().unwrap(), name);
+    }
+
+    #[test]
+    fn names_do_not_overlap() {
+        let mut table = hashbrown::HashMap::new();
+        for name in Builtin::exhaust() {
+            let string = name.static_string();
+            if let Some(other_name) = table.insert(string, name) {
+                panic!(
+                    "\
+name collision between {name:?} ({string:?})
+                   and {other_name:?} ({other_string:?})\
+                    ",
+                    other_string = other_name.static_string()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn unknown_builtin_error() {
+        let error = "nonexistent".parse::<Builtin>().unwrap_err();
+
+        assert_eq!(error, UnknownBuiltin(String::from("nonexistent")));
+        assert_eq!(error.to_string(), "unknown builtin 'nonexistent'");
+    }
+}

--- a/all-is-cubes/src/universe/handle.rs
+++ b/all-is-cubes/src/universe/handle.rs
@@ -18,9 +18,9 @@ use bevy_ecs::prelude as ecs;
 use bevy_platform::sync::{Mutex, MutexGuard, OnceLock};
 
 use crate::universe::{
-    self, AnyHandle, InsertError, InsertErrorKind, MemberBoilerplate, Membership, Name, ReadTicket,
-    ReadTicketError, SealedMember, Type, Universe, UniverseId, UniverseMember, VisitHandles,
-    id::OnceUniverseId,
+    self, AnyHandle, Builtin, InsertError, InsertErrorKind, MemberBoilerplate, Membership, Name,
+    ReadTicket, ReadTicketError, SealedMember, Type, Universe, UniverseId, UniverseMember,
+    VisitHandles, id::OnceUniverseId,
 };
 
 #[cfg(doc)]
@@ -107,6 +107,10 @@ enum State {
 
     /// Deleted or never existed.
     Gone { reason: GoneReason },
+
+    /// The handle is the unique handle corresponding to a [`Builtin`].
+    /// Its data is stored statically.
+    Builtin,
 }
 
 /// System parameter which allows reading a specific type of universe member.
@@ -150,6 +154,13 @@ impl<T: 'static> Handle<T> {
         Self::new_from_state(name, State::Pending)
     }
 
+    /// Constructs a new [`Handle`] for a builtin.
+    ///
+    /// This is used internally when lazily initializing [`Builtin`]s.
+    pub(in crate::universe) fn new_for_builtin_initialization(name: Builtin) -> Handle<T> {
+        Self::new_from_state(Name::Builtin(name), State::Builtin)
+    }
+
     /// Constructs a [`Handle`] that does not refer to a value, as if it used to but
     /// is now defunct.
     ///
@@ -157,14 +168,24 @@ impl<T: 'static> Handle<T> {
     /// When compared, this will be equal only to clones of itself.
     ///
     /// This may be used in tests to exercise error handling.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the name is [`Name::Builtin`]. Builtin handles are globally unique.
     #[doc(hidden)] // TODO: decide if this is good API
+    #[track_caller]
     pub fn new_gone(name: Name) -> Handle<T> {
-        Self::new_from_state(
-            name,
-            State::Gone {
-                reason: GoneReason::CreatedGone {},
-            },
-        )
+        match name {
+            Name::Specific(_) | Name::Anonym(_) | Name::Pending => Self::new_from_state(
+                name,
+                State::Gone {
+                    reason: GoneReason::CreatedGone {},
+                },
+            ),
+            Name::Builtin(_) => {
+                panic!("Handle::new_gone() may not be used on builtin names, such as {name}")
+            }
+        }
     }
 
     /// Constructs a [`Handle`] that has an associated entity but not yet a value.
@@ -286,6 +307,8 @@ impl<T: 'static> Handle<T> {
                 ticket_universe_id: Some(expected_universe),
                 ticket_origin: Location::caller(),
             })),
+
+            (_, State::Builtin) => Err(self.create_error(HandleErrorKind::Builtin)),
         }
     }
 
@@ -306,13 +329,18 @@ impl<T: 'static> Handle<T> {
                 ticket_universe_id: None,
                 ticket_origin: Location::caller(),
             })),
+
+            State::Builtin => Err(self.create_error(HandleErrorKind::Builtin)),
         }
     }
 
     /// Returns the unique ID of the universe this handle belongs to.
     ///
-    /// Returns [`None`] if this [`Handle`] is not yet associated with a universe, or if
-    /// it was created by [`Self::new_gone()`].
+    /// Returns [`None`] if this [`Handle`]:
+    ///
+    /// * points to a [`Builtin`],
+    /// * is not yet associated with a universe, or
+    /// * was created by [`Self::new_gone()`].
     ///
     /// The ID cannot be replaced; once [`Some`] is seen, the result will be stable forever.
     pub fn universe_id(&self) -> Option<UniverseId> {
@@ -322,11 +350,11 @@ impl<T: 'static> Handle<T> {
     /// Acquire read access to the referent of this handle.
     ///
     /// The caller must supply a [`ReadTicket`] from the [`Universe`] or [`UniverseTransaction`]
-    /// the handle belongs to.
+    /// the handle belongs to (except in case of [`Builtin`] handles, where the ticket is ignored).
     ///
     /// # Errors
     ///
-    /// Returns an error if the handle is invalid or the ticket does not match.
+    /// Returns an error if the handle is invalid or the ticket does not provide sufficient access.
     #[inline(never)]
     #[expect(clippy::missing_panics_doc, reason = "all panics are bugs")]
     pub fn read<'t>(&self, read_ticket: ReadTicket<'t>) -> Result<T::Read<'t>, HandleError>
@@ -338,12 +366,14 @@ impl<T: 'static> Handle<T> {
         /// but it makes things a little more clearly OK and slightly shortens the duration
         /// the state mutex is locked.
         enum Access {
+            Builtin,
             Pending,
             Entity(ecs::Entity),
         }
 
         // Use the state mutex to figure out how to obtain access.
         let access: Access = match *self.inner.state.lock().expect("Handle::state lock error") {
+            State::Builtin => Access::Builtin,
             State::Pending => Access::Pending,
             #[cfg(feature = "save")]
             State::Deserializing { entity: _ } => {
@@ -378,6 +408,20 @@ impl<T: 'static> Handle<T> {
 
         // Actually obtain access.
         Ok(match access {
+            Access::Builtin => {
+                let name = self.name();
+                let Name::Builtin(builtin_name) = name else {
+                    unreachable!("builtin handle {self:?} does not have a builtin name {name:?}")
+                };
+                let any_data: &universe::AnyPending = builtin_name.get();
+                let boxed_data: Option<&Option<Box<T>>> =
+                    any_data.value_as_any_option_box().downcast_ref();
+                let data: &T = boxed_data
+                    .expect("builtin handles should always have the right type")
+                    .as_ref()
+                    .expect("builtin handles should always have data");
+                T::read_from_standalone(data)
+            }
             Access::Pending => T::read_from_standalone(
                 read_ticket.borrow_pending(self).map_err(|e| e.into_handle_error(self))?,
             ),
@@ -421,8 +465,13 @@ impl<T: 'static> Handle<T> {
         }
     }
 
-    /// Like [`Self::read()`], but allows selecting an arbitrary component.
-    /// In the future, this will need to be the only way, and `read()` will be a facade, or something.
+    /// Like [`Self::read()`], but allows selecting an arbitrary component that is not part of
+    /// [`UniverseMember::Read`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if called on a handle which is not a member of a universe because it is pending
+    /// or builtin.
     pub(crate) fn query<'t, C: ecs::Component>(
         &self,
         read_ticket: ReadTicket<'t>,
@@ -433,9 +482,11 @@ impl<T: 'static> Handle<T> {
         // TODO(ecs): Deduplicate this setup code with read()
         let entity: ecs::Entity = match *self.inner.state.lock().expect("Handle::state lock error")
         {
+            State::Builtin => {
+                unreachable!("cannot use query() on builtin handles")
+            }
             State::Pending => {
-                // TODO(ecs): proper error
-                panic!("cannot use query() on pending handles")
+                unreachable!("cannot use query() on pending handles")
             }
             #[cfg(feature = "save")]
             State::Deserializing { entity: _ } => {
@@ -633,6 +684,7 @@ impl<T: fmt::Debug + 'static> fmt::Debug for Handle<T> {
                     #[cfg(feature = "save")]
                     State::Deserializing { .. } => write!(f, ", not yet deserialized")?,
                     State::Member { .. } => { /* normal condition, no message */ }
+                    State::Builtin => { /* condition explained by the name */ }
                     State::Gone { .. } => write!(f, ", gone")?,
                 }
             }
@@ -732,11 +784,11 @@ mod arbitrary_handle {
     impl<'a, T: arbitrary::Arbitrary<'a> + UniverseMember + 'static> arbitrary::Arbitrary<'a>
         for Handle<T>
     {
-        /// Do not call this! It will panic under most circumstances.
-        /// Because [`Handle`]s belong to a [`Universe`], they must be constructed together.
+        /// Because most [`Handle`]s belong to a [`Universe`], they must be constructed together.
+        /// Use [`ArbitraryWithUniverse`] to obtain useful arbitrary [`Handle`]s.
         fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
             Ok(match u.int_in_range(0..=2)? {
-                0 => Handle::new_gone(Name::arbitrary(u)?),
+                0 => Handle::new_gone(without_builtin_name(Name::arbitrary(u)?)),
                 1 => {
                     let name = Name::arbitrary(u)?;
                     let value = T::arbitrary(u)?;
@@ -745,7 +797,7 @@ mod arbitrary_handle {
                         context.universe.insert(name.clone(), value).unwrap_or_else(|_| {
                             // TODO: insert anonymous if picking an arbitrary name failed;
                             // right now we can't recover ownership of the value!
-                            Handle::new_gone(name)
+                            Handle::new_gone(without_builtin_name(name))
                         })
                     })
                     .unwrap_or_else(no_context)
@@ -800,6 +852,16 @@ mod arbitrary_handle {
             depth: usize,
         ) -> Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
             Handle::<T>::try_size_hint(depth)
+        }
+    }
+
+    /// If a name is [`Name::Builtin`], replace it.
+    /// This makes the name compatible with [`Handle::new_gone()`].
+    fn without_builtin_name(name: Name) -> Name {
+        if let Name::Builtin(b) = name {
+            Name::Specific(arcstr::format!("{b}"))
+        } else {
+            name
         }
     }
 
@@ -865,6 +927,9 @@ pub(crate) enum HandleErrorKind {
     /// been called.
     ValueMissing,
 
+    /// This handle is a [`Builtin`] handle; its referent cannot be mutated under any circumstances.
+    Builtin,
+
     /// The given [`ReadTicket`] is for a different universe,
     /// or a mutation function was called on a [`Universe`] which does not contain the given handle.
     //---
@@ -920,9 +985,11 @@ impl HandleError {
             HandleErrorKind::ValueMissing => None,
             HandleErrorKind::NotReady => None,
             HandleErrorKind::WrongUniverse { .. } => None,
+            HandleErrorKind::Builtin => None,
             HandleErrorKind::NotYetInserted { .. } => None,
         }
     }
+
     /// Returns whether the failed access might succeed at a later time,
     /// or with a strictly broader [`ReadTicket`].
     pub fn is_transient(&self) -> bool {
@@ -939,6 +1006,7 @@ impl HandleError {
             // Permanent failures.
             HandleErrorKind::WrongUniverse { .. } => false,
             HandleErrorKind::Gone { .. } => false,
+            HandleErrorKind::Builtin => false,
         }
     }
 
@@ -967,6 +1035,12 @@ impl fmt::Display for HandleError {
             }
             HandleErrorKind::ValueMissing => {
                 write!(f, "handle {handle_name} has no value yet")
+            }
+            HandleErrorKind::Builtin => {
+                write!(
+                    f,
+                    "handle {handle_name} cannot be mutated because it is a builtin"
+                )
             }
             HandleErrorKind::WrongUniverse {
                 ticket_universe_id,
@@ -1010,6 +1084,7 @@ impl core::error::Error for HandleError {
             HandleErrorKind::InUse => None,
             HandleErrorKind::NotReady => None,
             HandleErrorKind::ValueMissing => None,
+            HandleErrorKind::Builtin => None,
             HandleErrorKind::WrongUniverse { .. } => None,
             HandleErrorKind::NotYetInserted { .. } => None,
             HandleErrorKind::InvalidTicket { ref error } => Some(error),
@@ -1425,6 +1500,12 @@ mod tests {
         let r_different: Handle<Space> = Handle::new_gone("bar".into());
         assert_ne!(r1, r2);
         assert_ne!(r1, r_different);
+    }
+
+    #[test]
+    #[should_panic = "Handle::new_gone() may not be used on builtin names, such as builtin 'air'"]
+    fn new_gone_on_builtin() {
+        _ = Handle::<BlockDef>::new_gone(Name::Builtin(Builtin::Air));
     }
 
     #[test]

--- a/all-is-cubes/src/universe/members.rs
+++ b/all-is-cubes/src/universe/members.rs
@@ -523,9 +523,11 @@ macro_rules! member_enums_and_impls {
         }
 
         /// Holds a pending handle and its value, to be inserted into a universe.
+        /// Also used by builtins to store their state.
         ///
-        /// There is no validation that the handle is in fact pending.
-        /// This type is used only within [`crate::universe::universe_txn::MemberTxn`].
+        /// There is no validation of the handle’s actual state.
+        /// This type is used within [`crate::universe::universe_txn::MemberTxn`] and
+        /// [`crate::universe::builtin`].
         pub(in crate::universe) enum AnyPending {
             $(
                 $member_type {

--- a/all-is-cubes/src/universe/name.rs
+++ b/all-is-cubes/src/universe/name.rs
@@ -3,6 +3,8 @@ use core::fmt;
 
 use arcstr::ArcStr;
 
+use crate::universe::Builtin;
+
 #[cfg(doc)]
 use crate::universe::{Handle, Universe};
 
@@ -29,6 +31,10 @@ pub enum Name {
     ///
     /// This name is always replaced at the moment of insertion in the [`Universe`].
     Pending,
+
+    /// Refers to an immutable object defined in code which acts as if it is a member of every
+    /// [`Universe`].
+    Builtin(Builtin),
 }
 
 impl Name {
@@ -38,7 +44,9 @@ impl Name {
         match self {
             Name::Specific(_) => true,
             Name::Anonym(_) => false,
-            Name::Pending => unreachable!("inconsistency: Pending should not occur here"),
+            Name::Builtin(_) | Name::Pending => {
+                unreachable!("inconsistency: name of type {self} should not be subject to GC")
+            }
         }
     }
 }
@@ -61,12 +69,19 @@ impl From<ArcStr> for Name {
     }
 }
 
+impl From<Builtin> for Name {
+    fn from(value: Builtin) -> Self {
+        Name::Builtin(value)
+    }
+}
+
 impl fmt::Display for Name {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Name::Specific(name) => write!(f, "'{name}'"),
             Name::Anonym(index) => write!(f, "[anonymous #{index}]"),
             Name::Pending => write!(f, "[pending anonymous]"),
+            Name::Builtin(name) => write!(f, "builtin '{name}'"),
         }
     }
 }
@@ -75,11 +90,13 @@ impl fmt::Display for Name {
 #[cfg(feature = "arbitrary")]
 mod impl_arbitrary {
     use super::*;
+
     #[derive(arbitrary::Arbitrary)]
     enum ArbName {
         Specific(String),
         Anonym(usize),
         Pending,
+        Builtin(Builtin),
     }
 
     impl<'a> arbitrary::Arbitrary<'a> for Name {
@@ -89,6 +106,7 @@ mod impl_arbitrary {
                 ArbName::Specific(name) => Name::Specific(name.into()),
                 ArbName::Anonym(index) => Name::Anonym(index),
                 ArbName::Pending => Name::Pending,
+                ArbName::Builtin(builtin) => Name::Builtin(builtin),
             };
             if false {
                 // This non-executed code proves ArbName has as many variants as Name
@@ -96,6 +114,7 @@ mod impl_arbitrary {
                     Name::Specific(name) => ArbName::Specific(name.to_string()),
                     Name::Anonym(index) => ArbName::Anonym(index),
                     Name::Pending => ArbName::Pending,
+                    Name::Builtin(name) => ArbName::Builtin(name),
                 };
                 unreachable!()
             } else {

--- a/all-is-cubes/src/universe/tests.rs
+++ b/all-is-cubes/src/universe/tests.rs
@@ -17,7 +17,7 @@ use crate::space::Space;
 use crate::time;
 use crate::transaction::{self, Transaction};
 use crate::universe::{
-    self, GoneReason, Handle, HandleError, InsertError, InsertErrorKind, Name, ReadTicket,
+    self, Builtin, GoneReason, Handle, HandleError, InsertError, InsertErrorKind, Name, ReadTicket,
     Universe, UniverseTransaction, list_handles,
 };
 use crate::util::{assert_conditional_send_sync, yield_progress_for_testing};
@@ -139,6 +139,27 @@ fn get_any() {
 }
 
 #[test]
+fn get_builtin_handle() {
+    let u = Universe::new();
+    let name = Name::Builtin(Builtin::Air);
+    let expected_handle = Builtin::Air.handle::<BlockDef>();
+
+    assert_eq!(u.get(&name), Some(expected_handle.clone()));
+    assert_eq!(
+        u.get_any(&name),
+        Some::<&dyn universe::ErasedHandle>(expected_handle)
+    );
+}
+
+#[test]
+fn get_builtin_handle_with_wrong_type() {
+    let u = Universe::new();
+    let name = Name::Builtin(Builtin::Air);
+
+    assert_eq!(u.get::<Space>(&name), None);
+}
+
+#[test]
 fn insert_anonymous_makes_distinct_names() {
     let [block_0, block_1] = make_some_blocks();
     let mut u = Universe::new();
@@ -202,6 +223,41 @@ fn insert_duplicate_name_via_txn() {
 }
 
 #[test]
+fn insert_builtin_prohibited() {
+    assert_eq!(
+        Universe::new().insert(
+            Name::Builtin(Builtin::Air),
+            BlockDef::new(ReadTicket::stub(), AIR)
+        ),
+        Err(InsertError {
+            name: Name::Builtin(Builtin::Air),
+            kind: InsertErrorKind::InvalidName,
+        })
+    );
+}
+
+#[test]
+fn insert_builtin_prohibited_via_txn() {
+    let (_, txn) = UniverseTransaction::insert(
+        Name::Builtin(Builtin::Air),
+        BlockDef::new(ReadTicket::stub(), AIR),
+    );
+
+    assert_eq!(
+        txn.execute(&mut Universe::new(), (), &mut drop),
+        Err(transaction::ExecuteError::Check(
+            universe::UniverseMismatch::Member(transaction::MapMismatch {
+                key: Name::Builtin(Builtin::Air),
+                mismatch: universe::MemberMismatch::Insert(InsertError {
+                    name: Name::Builtin(Builtin::Air),
+                    kind: InsertErrorKind::InvalidName
+                })
+            })
+        ))
+    );
+}
+
+#[test]
 fn insert_anonym_prohibited_direct() {
     assert_eq!(
         Universe::new().insert(Name::Anonym(0), BlockDef::new(ReadTicket::stub(), AIR)),
@@ -215,18 +271,17 @@ fn insert_anonym_prohibited_direct() {
 #[test]
 fn insert_anonym_prohibited_via_txn() {
     let (_, txn) = UniverseTransaction::insert(Name::Anonym(0), Space::empty_positive(1, 1, 1));
-    let error = txn.execute(&mut Universe::new(), (), &mut drop).unwrap_err();
 
     assert_eq!(
-        error,
-        transaction::ExecuteError::Check(universe::UniverseMismatch::Member(
-            transaction::MapMismatch {
+        txn.execute(&mut Universe::new(), (), &mut drop),
+        Err(transaction::ExecuteError::Check(
+            universe::UniverseMismatch::Member(transaction::MapMismatch {
                 key: Name::Anonym(0),
                 mismatch: universe::MemberMismatch::Insert(InsertError {
                     name: Name::Anonym(0),
                     kind: InsertErrorKind::InvalidName
                 })
-            }
+            })
         ))
     );
 }
@@ -386,6 +441,26 @@ fn gc_implicit() {
 fn gc_preserves_named() {
     let mut u = Universe::new();
     u.insert("foo".into(), BlockDef::new(u.read_ticket(), AIR)).unwrap();
+    assert_eq!(1, u.iter_by_type::<BlockDef>().count());
+    u.gc();
+    assert_eq!(1, u.iter_by_type::<BlockDef>().count());
+    u.get::<BlockDef>(&"foo".into()).unwrap();
+}
+
+/// Builtins are not considered erroneous if encountered, despite not being stored in the universe.
+#[test]
+fn gc_allows_builtins() {
+    let mut u = Universe::new();
+    u.insert(
+        "foo".into(),
+        BlockDef::new(
+            u.read_ticket(),
+            Block::from_primitive(block::Primitive::Indirect(
+                Builtin::Air.handle::<BlockDef>().clone(),
+            )),
+        ),
+    )
+    .unwrap();
     assert_eq!(1, u.iter_by_type::<BlockDef>().count());
     u.gc();
     assert_eq!(1, u.iter_by_type::<BlockDef>().count());

--- a/all-is-cubes/src/universe/universe_txn.rs
+++ b/all-is-cubes/src/universe/universe_txn.rs
@@ -9,8 +9,8 @@ use hashbrown::HashMap as HbHashMap;
 
 use crate::transaction::{self, CommitError, Equal, Merge, Transaction, Transactional};
 use crate::universe::{
-    AnyPending, ErasedHandle, Handle, HandleError, InsertError, InsertErrorKind, MemberBoilerplate,
-    Name, ReadTicket, Universe, UniverseId, UniverseMember,
+    AnyPending, Builtin, ErasedHandle, Handle, HandleError, InsertError, InsertErrorKind,
+    MemberBoilerplate, Name, ReadTicket, Universe, UniverseId, UniverseMember,
 };
 
 // Reëxports for macro-generated types
@@ -66,6 +66,15 @@ where
     O: UniverseMember + Transactional,
     <O as Transactional>::Transaction: TransactionOnEcs,
 {
+    // Check that the handle is valid to write in this universe. This check:
+    // * Rejects `Builtin` handles.
+    // * Matches the `as_entity()` call we’re going to later do during commit.
+    //   (We could return the entity ID in the check value, but that would be exposing the potential
+    //   for exciting misbehaviors if the wrong check value gets here, so better to do it twice.)
+    let _: ecs::Entity = target
+        .as_entity(universe.universe_id())
+        .map_err(MismatchOrHandleError::Handle)?;
+
     let read_ticket = universe.read_ticket();
     let read = target.read(read_ticket).map_err(MismatchOrHandleError::Handle)?;
     TransactionOnEcs::check(transaction, read, read_ticket).map_err(MismatchOrHandleError::Check)
@@ -85,7 +94,7 @@ where
 {
     let entity: ecs::Entity = target
         .as_entity(universe.universe_id())
-        .expect("transaction target belongs to wrong universe");
+        .expect("as_entity() failed; universe state changed between check and commit");
     let query_state = O::member_mutation_query_state(&mut universe.queries.write_members);
     let target_query_data = query_state
         .get_mut(&mut universe.world, entity)
@@ -523,7 +532,10 @@ impl UniverseTransaction {
     }
 
     /// Given a handle that is newly created, add it to this transaction's set of handles to insert,
-    /// after validating the name.
+    /// after validating the name is not a duplicate within this transaction.
+    ///
+    /// Does not check that the name is valid to insert at all; in particular, it permits
+    /// [`Name::Anonym`] and [`Name::Builtin`]. Those will fail when the transaction is executed.
     ///
     /// Public functions do not allow passing arbitrary handles to this.
     fn insert_named_handle_inner<T: UniverseMember>(
@@ -534,7 +546,8 @@ impl UniverseTransaction {
         let insertion =
             MemberTxn::Insert(MemberBoilerplate::into_any_pending(handle.clone(), None));
         match name {
-            name @ (Name::Specific(_) | Name::Anonym(_)) => {
+            // Note:
+            name @ (Name::Specific(_) | Name::Anonym(_) | Name::Builtin(_)) => {
                 match self.members.entry(name.clone()) {
                     hashbrown::hash_map::Entry::Occupied(_) => {
                         // Equivalent to how transaction merge would fail
@@ -594,8 +607,11 @@ impl UniverseTransaction {
         &self,
         handle: &Handle<T>,
     ) -> Option<&Option<Box<T>>> {
+        // This match must be consistent with [`Self::insert_named_handle_inner`].
         let member_txn: &MemberTxn = match handle.name() {
-            name @ (Name::Specific(_) | Name::Anonym(_)) => self.members.get(&name),
+            name @ (Name::Specific(_) | Name::Anonym(_) | Name::Builtin(_)) => {
+                self.members.get(&name)
+            }
             Name::Pending => {
                 let handle: &dyn ErasedHandle = handle;
                 self.anonymous_insertions.get(handle)
@@ -628,8 +644,11 @@ impl UniverseTransaction {
         &mut self,
         handle: &Handle<T>,
     ) -> Option<&mut Option<Box<T>>> {
+        // This match must be consistent with [`Self::insert_named_handle_inner`].
         let member_txn: &mut MemberTxn = match handle.name() {
-            name @ (Name::Specific(_) | Name::Anonym(_)) => self.members.get_mut(&name),
+            name @ (Name::Specific(_) | Name::Anonym(_) | Name::Builtin(_)) => {
+                self.members.get_mut(&name)
+            }
             Name::Pending => {
                 let handle: &dyn ErasedHandle = handle;
                 self.anonymous_insertions.get_mut(handle)
@@ -878,14 +897,16 @@ impl MemberTxn {
         match (self, name) {
             (MemberTxn::Noop, _) => Ok(MemberCommitCheck(None)),
 
-            (MemberTxn::Modify(_), Name::Pending) => {
-                // This is a weird time to implement this constraint, but the alternative
-                // would be to check it when the `MemberTxn` is created, which would mean
-                // that `bind()` and other functions would need to become fallible.
-                // So, instead, we lean on the idea that transactions have all sorts of
-                // reasons for failing.
-                Err(MemberMismatch::Pending)
+            (MemberTxn::Modify(_) | MemberTxn::Delete, &Name::Builtin(b)) => {
+                Err(MemberMismatch::Builtin(b))
             }
+
+            // This is a weird time to implement these constraints, but the alternative
+            // would be to check them when the `MemberTxn` is created, which would mean
+            // that `bind()` and other functions would need to become fallible.
+            // So, instead, we lean on the idea that transactions have all sorts of
+            // reasons for failing.
+            (MemberTxn::Modify(_), Name::Pending) => Err(MemberMismatch::Pending),
 
             // Kludge: The individual `AnyTransaction`s embed the `Handle<T>` they operate on --
             // so we don't actually pass anything here.
@@ -896,10 +917,12 @@ impl MemberTxn {
             }
 
             // Note: this check is also present in Universe::allocate_name.
-            (MemberTxn::Insert(_), Name::Anonym(_)) => Err(MemberMismatch::Insert(InsertError {
-                name: name.clone(),
-                kind: InsertErrorKind::InvalidName,
-            })),
+            (MemberTxn::Insert(_), Name::Anonym(_) | Name::Builtin(_)) => {
+                Err(MemberMismatch::Insert(InsertError {
+                    name: name.clone(),
+                    kind: InsertErrorKind::InvalidName,
+                }))
+            }
 
             (MemberTxn::Insert(pending), Name::Specific(_) | Name::Pending) => {
                 {
@@ -1081,6 +1104,9 @@ pub enum MemberMismatch {
 
     /// universe transactions may not modify members that have not yet been inserted into the universe
     Pending,
+
+    /// universe transactions may not modify builtins, including builtin '{0}'
+    Builtin(Builtin),
 }
 
 impl core::error::Error for MemberMismatch {
@@ -1091,6 +1117,7 @@ impl core::error::Error for MemberMismatch {
             MemberMismatch::DeleteInvalid(_) => None,
             MemberMismatch::Modify(e) => e.source(),
             MemberMismatch::Pending => None,
+            MemberMismatch::Builtin(_) => None,
         }
     }
 }
@@ -1152,6 +1179,7 @@ mod tests {
     //! (where they are parallel with non-transaction behavior tests).
 
     use super::*;
+    use crate::block;
     use crate::block::AIR;
     use crate::block::BlockDef;
     use crate::content::make_some_blocks;
@@ -1433,6 +1461,38 @@ mod tests {
         assert_eq!(
             error.source().unwrap().to_string(),
             "object 'foo' was deleted"
+        );
+    }
+
+    #[test]
+    fn builtin_mutation_via_universe_transaction_fails() {
+        let mut u = Universe::new();
+        let handle: Handle<BlockDef> = Builtin::Air.handle().clone();
+        let txn = block::BlockDefTransaction::overwrite(AIR).bind(handle);
+
+        let err = txn.execute(&mut u, (), &mut transaction::no_outputs).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "transaction precondition not met in member builtin 'air'"
+        );
+        assert_eq!(
+            err.source().unwrap().to_string(),
+            "universe transactions may not modify builtins, including builtin 'air'"
+        );
+    }
+
+    #[test]
+    fn builtin_mutation_via_execute_1_fails() {
+        let mut u = Universe::new();
+        let handle: &Handle<BlockDef> = Builtin::Air.handle();
+        let txn = block::BlockDefTransaction::overwrite(AIR);
+
+        let err = u.execute_1(handle, txn).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "handle builtin 'air' cannot be mutated because it is a builtin"
         );
     }
 


### PR DESCRIPTION
Builtins are a new mechanism by which there can be handles with immutable values defined in code, which are available everywhere independent of `Universe`.

This is not yet used for anything real, but I plan to use it for builtin fonts, tags recognized by the code, and possibly tool and UI blocks. It will allow us to avoid defining ad-hoc enums which each need their own serialization versioning considerations, such as the current `Font` and `Tag` enums.