### PR TITLE
CI: Don’t save fuzz corpus on pull requests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -652,7 +652,7 @@ jobs:
     # Failed runs are useful to cache since they expand the corpus, so we use separate save and
     # restore steps per <https://github.com/actions/cache/tree/main/save#always-save-cache>
     - name: Save fuzzer corpus
-      if: ${{ always() }}
+      if: ${{ always() && github.event_name != 'pull_request' }}
       uses: actions/cache/save@v5
       with:
         key: fuzz-corpus


### PR DESCRIPTION
This is the same as I just did in 89d80cd07c25e78921b9a524d2f16928e36e896a, but for the fuzz-corpus cache instead of rust-cache.