### PR TITLE
gpu: Use `naga-rust-embed` to share uniform structs. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,7 @@ dependencies = [
  "itertools 0.15.0",
  "log",
  "macro_rules_attribute",
+ "naga-rust-embed",
  "num-traits",
  "pollster",
  "pretty_assertions",
@@ -3565,6 +3566,9 @@ name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "lock_api"
@@ -3773,6 +3777,55 @@ dependencies = [
  "spirv",
  "thiserror 2.0.18",
  "unicode-ident",
+]
+
+[[package]]
+name = "naga-rust-back"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17df434b5faaa6590902bf193ad0c79b3241cec3ad77d16746d6250de9d5513c"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.13.1",
+ "half",
+ "mutants 0.0.4",
+ "naga",
+ "once_cell",
+ "proc-macro2",
+]
+
+[[package]]
+name = "naga-rust-embed"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3633cc74f40cd1d78a8b4f6f1b1984dd49775840259335cb33e38695947517b2"
+dependencies = [
+ "naga-rust-macros",
+ "naga-rust-rt",
+]
+
+[[package]]
+name = "naga-rust-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46485380f5b1e387149bc6f0784c7dc123db71f770c62a49f73ae944fbb31060"
+dependencies = [
+ "litrs",
+ "naga",
+ "naga-rust-back",
+ "proc-macro2",
+]
+
+[[package]]
+name = "naga-rust-rt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12204286ea6fb2018756c0a458a4ec74c7418cc1a0742d3ac46bcb7cfdc55c7d"
+dependencies = [
+ "bytemuck",
+ "mutants 0.0.4",
+ "num-traits",
+ "paste",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ macro_rules_attribute = { version = "0.2.0", default-features = false }
 manyfmt = { version = "0.1.0", default-features = false }
 mint = { version = "0.5.9", default-features = false }
 mutants = { version = "0.0.4", default-features = false }
+naga-rust-embed = { version = "0.3.0", features = ["bytemuck"] }
 noise-functions = { version = "0.8.4", default-features = false, features = ["libm"] }
 nosy = { version = "0.3.0", default-features = false }
 num-traits = { version = "0.2.19", default-features = false }

--- a/all-is-cubes-gpu/Cargo.toml
+++ b/all-is-cubes-gpu/Cargo.toml
@@ -69,6 +69,7 @@ half = { workspace = true, features = ["bytemuck"] }
 hashbrown = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
+naga-rust-embed = { workspace = true }
 num-traits = { workspace = true }
 # Used to implement start_polling() on non-Wasm targets, and in the `rerun` support.
 pollster = { workspace = true }

--- a/all-is-cubes-gpu/src/camera.rs
+++ b/all-is-cubes-gpu/src/camera.rs
@@ -1,40 +1,20 @@
+use naga_rust_embed::rt;
+
 use all_is_cubes::euclid::Transform3D;
 use all_is_cubes_render::camera::{AntialiasingOption, Camera, FogOption, LightingOption};
+
+// -------------------------------------------------------------------------------------------------
 
 /// Information corresponding to [`Camera`] but in a form suitable for passing in a
 /// uniform buffer to the `blocks-and-lines.wgsl` shader. Also includes some miscellaneous
 /// data for rendering [`Space`], which hasn't yet demonstrated enough distinction
 /// to be worth putting in a separate buffer.
-#[repr(C, align(16))] // align triggers bytemuck error if the size doesn't turn out to be a multiple
-#[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-pub(crate) struct ShaderSpaceCamera {
-    projection_matrix: [[f32; 4]; 4],
-    pub(super) inverse_projection_matrix: [[f32; 4]; 4],
-    view_matrix: [[f32; 4]; 4],
-
-    // --- 16-byte aligned point ---
-    /// Eye position in world coordinates. Used for computing distance
-    /// in volumetric rendering.
-    view_position: [f32; 3],
-
-    /// Scale factor for scene brightness.
-    exposure: f32,
-
-    // --- 16-byte aligned point ---
-    /// Light rendering style to use; a copy of [`GraphicsOptions::lighting_display`].
-    light_option: i32,
-
-    /// 0 or 1 indicating whether to apply antialiasing to block texture texel edges.
-    antialiasing_option: i32,
-
-    /// Fog equation blending: 0 is realistic fog and 1 is distant more abrupt fog.
-    fog_mode_blend: f32,
-    /// How far out should be fully fogged?
-    fog_distance: f32,
-}
+pub(crate) use crate::shaders::blocks_and_lines::ShaderSpaceCamera;
 
 impl ShaderSpaceCamera {
-    pub fn new(camera: &Camera) -> Self {
+    // We can’t call this function `new()` because it conflicts with the automatic shader-style
+    // new() function. TODO: consider making naga-rust-embed not hog that name.
+    pub fn from_camera(camera: &Camera) -> Self {
         let options = camera.options();
         let view_distance = camera.view_distance().into_inner() as f32;
 
@@ -54,14 +34,14 @@ impl ShaderSpaceCamera {
 
         // If the matrix isn't invertible, then what we're rendering must be degenerate (e.g.
         // zero FOV), so use a mostly harmless placeholder.
-        let inverse_projection_matrix =
+        let inverse_projection =
             convert_matrix(projection_matrix.inverse().unwrap_or(Transform3D::identity()));
 
         Self {
-            projection_matrix: convert_matrix(projection_matrix),
-            inverse_projection_matrix,
+            projection: convert_matrix(projection_matrix),
+            inverse_projection,
             view_matrix: convert_matrix(camera.view_matrix()),
-            view_position: camera.view_position().map(|s| s as f32).to_vector().into(),
+            view_position: camera.view_position().map(|s| s as f32).to_vector().to_array().into(),
 
             light_option: match options.lighting_display {
                 LightingOption::None => 0,
@@ -90,6 +70,6 @@ impl ShaderSpaceCamera {
     }
 }
 
-pub(crate) fn convert_matrix<Src, Dst>(matrix: Transform3D<f64, Src, Dst>) -> [[f32; 4]; 4] {
-    matrix.cast::<f32>().to_arrays()
+pub(crate) fn convert_matrix<Src, Dst>(matrix: Transform3D<f64, Src, Dst>) -> rt::Mat4x4<f32> {
+    rt::Mat4x4::from_column_arrays(matrix.cast::<f32>().to_arrays())
 }

--- a/all-is-cubes-gpu/src/everything.rs
+++ b/all-is-cubes-gpu/src/everything.rs
@@ -707,14 +707,16 @@ impl EverythingRenderer {
             0,
             const { buffer_size_of::<postprocess::PostprocessUniforms>() },
         )
-        .copy_from_slice(bytemuck::bytes_of(&postprocess::PostprocessUniforms::new(
-            self.cameras.graphics_options(),
-            self.cameras.viewport(),
-            self.fb.config().maximum_intensity,
-            self.fb.config().output_color_space,
-            self.info_text_coordinate_scale,
-            &self.pipelines.info_text_font_metrics,
-        )));
+        .copy_from_slice(bytemuck::bytes_of(
+            &postprocess::PostprocessUniforms::from_options(
+                self.cameras.graphics_options(),
+                self.cameras.viewport(),
+                self.fb.config().maximum_intensity,
+                self.fb.config().output_color_space,
+                self.info_text_coordinate_scale,
+                &self.pipelines.info_text_font_metrics,
+            ),
+        ));
 
         // If we're copying the scene image to Rerun, then start that copy now.
         #[cfg(feature = "rerun")]

--- a/all-is-cubes-gpu/src/postprocess.rs
+++ b/all-is-cubes-gpu/src/postprocess.rs
@@ -306,41 +306,12 @@ pub(crate) fn create_postprocess_pipeline(
 // -------------------------------------------------------------------------------------------------
 
 /// Contents of the uniform buffer updated every frame and read by `postprocess.wgsl`.
-#[repr(C, align(16))] // align triggers bytemuck error if the size doesn't turn out to be a multiple
-#[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-pub(crate) struct PostprocessUniforms {
-    /// Scale factors transforming from the viewport extent in 0.0..1.0 coordinates
-    /// to `info_text_texture` sampling coordinates.
-    ///
-    /// These factors are not simple because `info_text_texture`’s size is in character cells,
-    /// which are to be some exact multiple of framebuffer pixels.
-    info_text_coordinate_scale: [f32; 2],
-
-    /// Position of the top-left corner of the info text’s top-left character cell,
-    /// in 0.0..1.0 coordinates.
-    info_text_origin: [f32; 2],
-
-    // --- 16-byte aligned point ---
-    /// Size of a single character cell in `font_texture`.
-    font_cell_size: [u32; 2],
-
-    font_cell_margin: u32,
-
-    tone_mapping_id: i32,
-
-    // --- 16-byte aligned point ---
-    color_space_id: i32,
-
-    maximum_intensity: f32,
-
-    bloom_intensity: f32,
-
-    // Adjust this as needed to make a multiple of 16 bytes
-    _padding: [u32; 1],
-}
+pub(crate) use crate::shaders::postprocess::PostprocessUniforms;
 
 impl PostprocessUniforms {
-    pub(crate) fn new(
+    // We can’t call this function `new()` because it conflicts with the automatic shader-style
+    // new() function. TODO: consider making naga-rust-embed not hog that name.
+    pub(crate) fn from_options(
         options: &GraphicsOptions,
         viewport: Viewport,
         surface_maximum_intensity: PositiveSign<f32>,
@@ -349,13 +320,14 @@ impl PostprocessUniforms {
         info_text_font_metrics: &GpuFontMetrics,
     ) -> Self {
         Self {
-            info_text_coordinate_scale: info_text_coordinate_scale.into(),
+            info_text_coordinate_scale: info_text_coordinate_scale.to_array().into(),
             info_text_origin: vec2(5., 5.)
                 .component_div(viewport.nominal_size.to_vector())
                 .to_f32()
+                .to_array()
                 .into(),
 
-            font_cell_size: info_text_font_metrics.atlas_cell_size.into(),
+            font_cell_size: info_text_font_metrics.atlas_cell_size.to_array().into(),
             font_cell_margin: info_text_font_metrics.cell_margin,
 
             tone_mapping_id: if options.maximum_intensity.is_finite() {

--- a/all-is-cubes-gpu/src/raytrace_to_texture.rs
+++ b/all-is-cubes-gpu/src/raytrace_to_texture.rs
@@ -467,6 +467,7 @@ impl RaytraceToTexture {
                         .to_f32()
                         .to_vector()
                         .component_div(render_viewport.framebuffer_size.to_f32().to_vector())
+                        .to_array()
                         .into(),
                     _padding: Default::default(),
                 }),
@@ -976,21 +977,7 @@ impl raytracer::Accumulate for Split {
 
 // -------------------------------------------------------------------------------------------------
 
-#[repr(C, align(16))] // align triggers bytemuck error if the size doesn't turn out to be a multiple
-#[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-struct ReprojectionUniforms {
-    /// Matrix transforming points in the old camera's clip space to the new camera's clip space.
-    reprojection_matrix: [[f32; 4]; 4],
-    /// Inverse of the current projection matrix, used for transforming depths.
-    /// (In principle we should be passing the old projection matrix and new projection matrix,
-    /// but that's overkill.
-    inverse_projection: [[f32; 4]; 4],
-
-    /// Scale factors which scale texels in the input textures, the raytracing buffer textures,
-    /// into the viewport of the render target. Inverse of what `raytracer_size_policy()` did.
-    output_pixel_scale: [f32; 2],
-    _padding: [f32; 2],
-}
+use crate::shaders::rt_copy::ReprojectionUniforms;
 
 // -------------------------------------------------------------------------------------------------
 

--- a/all-is-cubes-gpu/src/rerun_image.rs
+++ b/all-is-cubes-gpu/src/rerun_image.rs
@@ -13,6 +13,9 @@ use crate::common::Memo;
 use crate::glue::{buffer_size_of, size2d_to_extent};
 use crate::init;
 use crate::pipelines::Pipelines;
+use crate::shaders::rerun_copy::RerunCopyCamera;
+
+// -------------------------------------------------------------------------------------------------
 
 pub(crate) struct RerunImageExport {
     device: wgpu::Device,
@@ -166,8 +169,8 @@ impl RerunImageExport {
             .expect("TODO: when does this even fail?")
             .copy_from_slice(bytemuck::bytes_of(&RerunCopyCamera {
                 // a bit wasteful to construct entire `ShaderSpaceCamera`, but avoids inconsistency
-                inverse_projection_matrix: ShaderSpaceCamera::new(normal_camera)
-                    .inverse_projection_matrix,
+                inverse_projection: ShaderSpaceCamera::from_camera(normal_camera)
+                    .inverse_projection,
             }));
 
         {
@@ -293,13 +296,6 @@ fn perform_image_copy(
             transform,
         )
     })
-}
-
-/// Uniform buffer struct for the `rerun-copy.wgsl` shader.
-#[repr(C, align(16))] // align triggers bytemuck error if the size doesn't turn out to be a multiple
-#[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-struct RerunCopyCamera {
-    inverse_projection_matrix: [[f32; 4]; 4],
 }
 
 /// Policy about how to downsample the scene to produce a sane amount of Rerun data.

--- a/all-is-cubes-gpu/src/shader_testing.rs
+++ b/all-is-cubes-gpu/src/shader_testing.rs
@@ -7,6 +7,9 @@
 //!
 //! The code in this module is located here so that we do not need to make many pieces
 //! of the infrastructure, like `FramebufferTextures`, `pub`, but only this module.
+//!
+//! TODO: Replace this with testing via `naga-rust-embed` which does not require actually
+//! talking to the GPU and has easier data flow.
 
 use alloc::string::{String, ToString as _};
 use alloc::sync::Arc;
@@ -203,7 +206,7 @@ where
     queue.write_buffer(
         &camera_buffer.buffer,
         0,
-        bytemuck::bytes_of(&ShaderSpaceCamera::new(&camera)),
+        bytemuck::bytes_of(&ShaderSpaceCamera::from_camera(&camera)),
     );
 
     let mut encoder =

--- a/all-is-cubes-gpu/src/shaders.rs
+++ b/all-is-cubes-gpu/src/shaders.rs
@@ -168,3 +168,28 @@ impl ReloadableShader {
         }
     }
 }
+
+// Translate shader structs to Rust, so we can use them as uniform buffer layouts.
+//
+// This translation does not interact with the hot-reloading system: if the reloaded shader code
+// has a different struct layout, things will break.
+//
+// TODO: Under cfg(test), make this translation include the functions so we can test the functions.
+macro_rules! include_wgsl {
+    ($mod_name:ident, $path:literal) => {
+        pub(crate) mod $mod_name {
+            naga_rust_embed::include_wgsl_mr!(
+                include_functions = false,
+                public_items = true,
+                rule(derive(bytemuck::NoUninit)),
+                $path
+            );
+        }
+    };
+}
+include_wgsl!(blocks_and_lines, "src/shaders/blocks-and-lines.wgsl");
+include_wgsl!(postprocess, "src/shaders/postprocess.wgsl");
+include_wgsl!(rerun_copy, "src/shaders/rerun-copy.wgsl");
+// resampling.wgsl has no structs to share.
+include_wgsl!(rt_copy, "src/shaders/rt-copy.wgsl");
+// uniform-color.wgsl has no structs to share.

--- a/all-is-cubes-gpu/src/shaders/blocks-and-lines.wgsl
+++ b/all-is-cubes-gpu/src/shaders/blocks-and-lines.wgsl
@@ -1,17 +1,25 @@
 // --- Interface declarations --------------------------------------------------
 
-// Mirrors `struct ShaderSpaceCamera` on the Rust side.
+// Information corresponding to `all_is_cubes::render::Camera`. Also includes some miscellaneous
+// data for rendering [`Space`], which hasn't yet demonstrated enough distinction
+// to be worth putting in a separate buffer.
 struct ShaderSpaceCamera {
     projection: mat4x4<f32>,
     inverse_projection: mat4x4<f32>,
     view_matrix: mat4x4<f32>,
     // --- 16-byte aligned point ---
+    // Eye position in world coordinates. Used for computing distance in volumetric rendering.
     view_position: vec3<f32>,
+    // Scale factor for scene brightness.
     exposure: f32,
     // --- 16-byte aligned point ---
+    // Light rendering style to use; a copy of [`GraphicsOptions::lighting_display`].
     light_option: i32,
+    /// 0 or 1 indicating whether to apply antialiasing to block texture texel edges.
     antialiasing_option: i32,
+    // Fog equation blending: 0 is realistic fog and 1 is distant more abrupt fog.
     fog_mode_blend: f32,
+    // How far out should be fully fogged?
     fog_distance: f32,
 }
 

--- a/all-is-cubes-gpu/src/shaders/postprocess.wgsl
+++ b/all-is-cubes-gpu/src/shaders/postprocess.wgsl
@@ -1,10 +1,17 @@
 // --- Interface declarations --------------------------------------------------
 
-// Mirrors `struct PostprocessUniforms` on the Rust side.
 struct PostprocessUniforms {
+    // Scale factors transforming from the viewport extent in 0.0..1.0 coordinates
+    // to `info_text_texture` sampling coordinates.
+    //
+    // These factors are not simple because `info_text_texture`’s size is in character cells,
+    // which are to be some exact multiple of framebuffer pixels.
     info_text_coordinate_scale: vec2f,
+    // Position of the top-left corner of the info text’s top-left character cell,
+    // in 0.0..1.0 coordinates.
     info_text_origin: vec2f,
     // --- 16-byte aligned point ---
+    // Size of a single character cell in `font_texture`.
     font_cell_size: vec2u,
     font_cell_margin: u32,
     tone_mapping_id: i32,
@@ -12,6 +19,7 @@ struct PostprocessUniforms {
     color_space_id: i32,
     maximum_intensity: f32,
     bloom_intensity: f32,
+    // Adjust this as needed to make a multiple of 16 bytes
     _padding: i32,
 }
 

--- a/all-is-cubes-gpu/src/shaders/rt-copy.wgsl
+++ b/all-is-cubes-gpu/src/shaders/rt-copy.wgsl
@@ -3,9 +3,16 @@
 // --- Interface declarations --------------------------------------------------
 
 struct ReprojectionUniforms {
+    // Matrix transforming points in the old camera's clip space to the new camera's clip space.
     reprojection_matrix: mat4x4<f32>,
+    // Inverse of the current projection matrix, used for transforming depths.
+    // (In principle we should be passing the old projection matrix and new projection matrix,
+    // but that's overkill.
     inverse_projection: mat4x4<f32>,
+    // Scale factors which scale texels in the input textures, the raytracing buffer textures,
+    // into the viewport of the render target. Inverse of what `raytracer_size_policy()` did.
     output_pixel_scale: vec2<f32>,
+    // Adjust this as needed to make a multiple of 16 bytes
     _padding: vec2<f32>,
 }
 

--- a/all-is-cubes-gpu/src/space.rs
+++ b/all-is-cubes-gpu/src/space.rs
@@ -808,7 +808,7 @@ impl SpaceRenderer {
             0,
             const { buffer_size_of::<ShaderSpaceCamera>() },
         )
-        .copy_from_slice(bytemuck::bytes_of(&ShaderSpaceCamera::new(camera)));
+        .copy_from_slice(bytemuck::bytes_of(&ShaderSpaceCamera::from_camera(camera)));
     }
 
     /// Returns the camera, to allow additional drawing in the same coordinate system.

--- a/all-is-cubes-wasm/Cargo.lock
+++ b/all-is-cubes-wasm/Cargo.lock
@@ -108,6 +108,7 @@ dependencies = [
  "hashbrown 0.17.0",
  "itertools",
  "log",
+ "naga-rust-embed",
  "num-traits",
  "pollster",
  "pretty_assertions",
@@ -1150,6 +1151,9 @@ name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "lock_api"
@@ -1265,6 +1269,55 @@ dependencies = [
  "rustc-hash 1.1.0",
  "thiserror",
  "unicode-ident",
+]
+
+[[package]]
+name = "naga-rust-back"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17df434b5faaa6590902bf193ad0c79b3241cec3ad77d16746d6250de9d5513c"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "half",
+ "mutants 0.0.4",
+ "naga",
+ "once_cell",
+ "proc-macro2",
+]
+
+[[package]]
+name = "naga-rust-embed"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3633cc74f40cd1d78a8b4f6f1b1984dd49775840259335cb33e38695947517b2"
+dependencies = [
+ "naga-rust-macros",
+ "naga-rust-rt",
+]
+
+[[package]]
+name = "naga-rust-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46485380f5b1e387149bc6f0784c7dc123db71f770c62a49f73ae944fbb31060"
+dependencies = [
+ "litrs",
+ "naga",
+ "naga-rust-back",
+ "proc-macro2",
+]
+
+[[package]]
+name = "naga-rust-rt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12204286ea6fb2018756c0a458a4ec74c7418cc1a0742d3ac46bcb7cfdc55c7d"
+dependencies = [
+ "bytemuck",
+ "mutants 0.0.4",
+ "num-traits",
+ "paste",
 ]
 
 [[package]]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1065,7 +1065,8 @@ checksum = "add0ac067452ff1aca8c5002111bd6b1c895baee6e45fcbc44e0193aea17be56"
 [[package]]
 name = "naga"
 version = "30.0.0"
-source = "git+https://github.com/gfx-rs/wgpu/?branch=trunk#8bf3e5ff4ab45e2c150e0d6c70d01d25f5b126c1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23bf0a141a9ab6f07dbb492db53245e464bc9db42f407772d9ae03d83a2c1033"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -1089,7 +1090,8 @@ dependencies = [
 [[package]]
 name = "naga-types"
 version = "30.0.0"
-source = "git+https://github.com/gfx-rs/wgpu/?branch=trunk#8bf3e5ff4ab45e2c150e0d6c70d01d25f5b126c1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658200ddc25c6c7b860747516d132d1b284c0fafb7a380233acee9a72fb30e11"
 dependencies = [
  "hashbrown 0.17.0",
  "indexmap",
@@ -1802,7 +1804,8 @@ dependencies = [
 [[package]]
 name = "wgpu"
 version = "30.0.0"
-source = "git+https://github.com/gfx-rs/wgpu/?branch=trunk#8bf3e5ff4ab45e2c150e0d6c70d01d25f5b126c1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d8f4bd44d92da5270f03409dba9f952dab24f128e05d6a554926101d1bf9114"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -1829,7 +1832,8 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "30.0.0"
-source = "git+https://github.com/gfx-rs/wgpu/?branch=trunk#8bf3e5ff4ab45e2c150e0d6c70d01d25f5b126c1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08763620e76fc980bca7bf84de82568614487a53172dd968d89187282eb87fa2"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -1860,7 +1864,8 @@ dependencies = [
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
 version = "30.0.0"
-source = "git+https://github.com/gfx-rs/wgpu/?branch=trunk#8bf3e5ff4ab45e2c150e0d6c70d01d25f5b126c1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f76bc9c1c186ff3d9054e0d224c93c8c1c79d6653907c5249a5c1ea1a2cb1e43"
 dependencies = [
  "wgpu-hal",
 ]
@@ -1868,7 +1873,8 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "30.0.0"
-source = "git+https://github.com/gfx-rs/wgpu/?branch=trunk#8bf3e5ff4ab45e2c150e0d6c70d01d25f5b126c1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf765132d8d5f50e192e7880464890c13f4e7457aafe8e5466e8174586e9f101"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1891,7 +1897,8 @@ dependencies = [
 [[package]]
 name = "wgpu-naga-bridge"
 version = "30.0.0"
-source = "git+https://github.com/gfx-rs/wgpu/?branch=trunk#8bf3e5ff4ab45e2c150e0d6c70d01d25f5b126c1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9eaac644e5008925c78567d272b9d66ef83da55a53cc17fc7daade7bb6e66e5"
 dependencies = [
  "naga",
  "wgpu-types",
@@ -1900,7 +1907,8 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "30.0.0"
-source = "git+https://github.com/gfx-rs/wgpu/?branch=trunk#8bf3e5ff4ab45e2c150e0d6c70d01d25f5b126c1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a9c93c2b35edde326df60ffdee4c0f5864eac3011d6768b70d43f028ad93565"
 dependencies = [
  "bitflags",
  "bytemuck",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "hashbrown 0.17.0",
  "itertools",
  "log",
+ "naga-rust-embed",
  "num-traits",
  "pollster",
  "pretty_assertions",
@@ -980,6 +981,9 @@ name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "lock_api"
@@ -1085,6 +1089,55 @@ dependencies = [
  "rustc-hash 1.1.0",
  "thiserror",
  "unicode-ident",
+]
+
+[[package]]
+name = "naga-rust-back"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17df434b5faaa6590902bf193ad0c79b3241cec3ad77d16746d6250de9d5513c"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "half",
+ "mutants 0.0.4",
+ "naga",
+ "once_cell",
+ "proc-macro2",
+]
+
+[[package]]
+name = "naga-rust-embed"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3633cc74f40cd1d78a8b4f6f1b1984dd49775840259335cb33e38695947517b2"
+dependencies = [
+ "naga-rust-macros",
+ "naga-rust-rt",
+]
+
+[[package]]
+name = "naga-rust-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46485380f5b1e387149bc6f0784c7dc123db71f770c62a49f73ae944fbb31060"
+dependencies = [
+ "litrs",
+ "naga",
+ "naga-rust-back",
+ "proc-macro2",
+]
+
+[[package]]
+name = "naga-rust-rt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12204286ea6fb2018756c0a458a4ec74c7418cc1a0742d3ac46bcb7cfdc55c7d"
+dependencies = [
+ "bytemuck",
+ "mutants 0.0.4",
+ "num-traits",
+ "paste",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -24,7 +24,7 @@ pretty_assertions = { version = "1.2.0" }
 # Here are some patches we might want to apply for development:
 #
 # exhaust = { git = "https://github.com/kpreid/exhaust/", branch = "main" }
-wgpu = { git = "https://github.com/gfx-rs/wgpu/", branch = "trunk" }
+# wgpu = { git = "https://github.com/gfx-rs/wgpu/", branch = "trunk" }
 
 [[bin]]
 name = "fuzz_block_eval"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -566,6 +566,30 @@ user-id = 98157 # Kevin Reid (kpreid)
 start = "2023-10-07"
 end = "2026-03-08"
 
+[[trusted.naga-rust-back]]
+criteria = "safe-to-deploy"
+user-id = 98157 # Kevin Reid (kpreid)
+start = "2025-03-26"
+end = "2027-07-28"
+
+[[trusted.naga-rust-embed]]
+criteria = "safe-to-deploy"
+user-id = 98157 # Kevin Reid (kpreid)
+start = "2025-03-26"
+end = "2027-07-28"
+
+[[trusted.naga-rust-macros]]
+criteria = "safe-to-deploy"
+user-id = 98157 # Kevin Reid (kpreid)
+start = "2025-03-26"
+end = "2027-07-28"
+
+[[trusted.naga-rust-rt]]
+criteria = "safe-to-deploy"
+user-id = 98157 # Kevin Reid (kpreid)
+start = "2025-03-26"
+end = "2027-07-28"
+
 [[trusted.nosy]]
 criteria = "safe-to-deploy"
 user-id = 98157 # Kevin Reid (kpreid)

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -183,6 +183,34 @@ user-id = 98157
 user-login = "kpreid"
 user-name = "Kevin Reid"
 
+[[publisher.naga-rust-back]]
+version = "0.3.0"
+when = "2026-07-28"
+user-id = 98157
+user-login = "kpreid"
+user-name = "Kevin Reid"
+
+[[publisher.naga-rust-embed]]
+version = "0.3.0"
+when = "2026-07-28"
+user-id = 98157
+user-login = "kpreid"
+user-name = "Kevin Reid"
+
+[[publisher.naga-rust-macros]]
+version = "0.3.0"
+when = "2026-07-28"
+user-id = 98157
+user-login = "kpreid"
+user-name = "Kevin Reid"
+
+[[publisher.naga-rust-rt]]
+version = "0.3.0"
+when = "2026-07-28"
+user-id = 98157
+user-login = "kpreid"
+user-name = "Kevin Reid"
+
 [[publisher.nosy]]
 version = "0.3.0"
 when = "2025-11-18"
@@ -309,8 +337,8 @@ user-login = "rerunio"
 user-name = "Rerun"
 
 [[publisher.re_span]]
-version = "0.33.0"
-when = "2026-05-29"
+version = "0.34.1"
+when = "2026-07-07"
 user-id = 197939
 user-login = "rerunio"
 user-name = "Rerun"


### PR DESCRIPTION
Eventually, I want to also use it for shader testing (otherwise, it wouldn’t really be worth doing), but that will be a largely separate process.