### PR TITLE
CI: Replace taiki-e/install-action with `cargo install`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,11 +141,11 @@ jobs:
 
     - name: Install tools for cache
       background: true # post-run cache save will automatically wait for this
-      # cargo-mutants and cargo-about are not used in this job but will be cached for later use.
+      # These tools are not used directly in this job but will be cached for later use.
       # We build them in this step so we can write them into the cache, whereas the dependent jobs
-      # don’t write the cache at all.
+      # (or the independent miri job) don’t write the cache at all.
       run: |
-        cargo install --locked cargo-about@0.8.2 cargo-mutants@27.0.0
+        cargo install --locked cargo-about@0.8.2 cargo-mutants@27.0.0 cargo-nextest@0.9.140
 
     - run: df -h .
 
@@ -576,9 +576,10 @@ jobs:
         # the default branch’s cache will be still be loaded.
         save-if: ${{ github.event_name != 'pull_request' }}
     - run: rustup toolchain install nightly --component miri
-    - uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # v2.83.4
-      with:
-        tool: nextest@0.9
+
+    # Install cargo-nextest, used by xtask.
+    # This should usually be already installed, but is present in case of cache miss
+    - run: cargo install --locked  cargo-nextest@0.9.140
 
     - name: Compile xtask
       run: cargo build --package=xtask

--- a/.github/workflows/unstable-ci.yml
+++ b/.github/workflows/unstable-ci.yml
@@ -99,6 +99,14 @@ jobs:
       run: |
         cargo install --locked wasm-pack@0.14.0
 
+    - name: Install tools for cache
+      background: true # post-run cache save will automatically wait for this
+      # These tools are not used directly in this job but will be cached for later use.
+      # We build them in this step so we can write them into the cache, whereas the dependent jobs
+      # (or the independent miri job) don’t write the cache at all.
+      run: |
+        cargo install --locked cargo-nextest@0.9.140
+
     - name: Set Rust toolchain
       # The rust-toolchain.toml file specifies the targets and components we need,
       # but we may want to override the toolchain.
@@ -233,9 +241,10 @@ jobs:
         # the default branch’s cache will be still be loaded.
         save-if: ${{ github.event_name != 'pull_request' }}
     - run: rustup toolchain install nightly --component miri
-    - uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # v2.83.4
-      with:
-        tool: nextest@0.9
+
+    # Install cargo-nextest, used by xtask.
+    # This should usually be already installed, but is present in case of cache miss
+    - run: cargo install --locked  cargo-nextest@0.9.140
 
     - name: Compile xtask
       run: cargo build --package=xtask


### PR DESCRIPTION
This removes a dependency and makes things more uniform. The cost is rebuilding nextest in the event of a cache miss, twice due to the `miri` job not depending on the `build` job.