### PR TITLE
desktop: Keep the progress notification up during light precomputation.

### DIFF
--- a/all-is-cubes-desktop/src/universe_source.rs
+++ b/all-is-cubes-desktop/src/universe_source.rs
@@ -44,7 +44,11 @@ impl UniverseSource {
         let start_time = Instant::now();
 
         // TODO: figure out a cleaner way to wrangle this rx hookup
-        let notif_rx = Mutex::new(TryRecvKeep::Rx(notif_rx));
+        //
+        // This is shared rather than owned by the `yield_progress` callback because the
+        // notification must outlive universe construction: `--precompute-light` runs afterward
+        // and is also part of what the user is waiting for.
+        let notif_rx = Arc::new(Mutex::new(TryRecvKeep::Rx(notif_rx)));
         #[allow(clippy::literal_string_with_formatting_args)]
         let universe_progress_bar = logging::new_progress_bar(100)
             .with_style(
@@ -56,6 +60,7 @@ impl UniverseSource {
         universe_progress_bar.set_position(0);
         let yield_progress = {
             let universe_progress_bar = universe_progress_bar.clone();
+            let notif_rx = Arc::clone(&notif_rx);
             glue::make_yield_progress()
                 .progress_using(move |info| {
                     universe_progress_bar.set_position((info.fraction() * 100.0) as u64);
@@ -139,9 +144,17 @@ impl UniverseSource {
             if precompute_light {
                 let space_handle =
                     character_handle.read(universe.read_ticket()).unwrap().space().clone();
-                universe.mutate_space(&space_handle, evaluate_light_with_progress).unwrap();
+                universe
+                    .mutate_space(&space_handle, |m| {
+                        evaluate_light_with_progress(m, &notif_rx)
+                    })
+                    .unwrap();
             }
         }
+
+        // Everything the user was waiting for is done, so take down the notification.
+        // (Dropping the `Notification` is what removes it from the `notification::Hub`.)
+        drop(notif_rx);
 
         Ok(universe)
     }
@@ -197,20 +210,38 @@ impl std::str::FromStr for Teleport {
 
 // -------------------------------------------------------------------------------------------------
 
-fn evaluate_light_with_progress(m: &mut space::Mutation<'_, '_>) {
+fn evaluate_light_with_progress(m: &mut space::Mutation<'_, '_>, notif_rx: &Mutex<TryRecvKeep>) {
     let light_progress = logging::new_progress_bar(100).with_prefix("Lighting");
-    m.evaluate_light(1, lighting_progress_adapter(&light_progress));
+    m.evaluate_light(1, lighting_progress_adapter(&light_progress, notif_rx));
     light_progress.finish();
 }
 
-/// Convert `LightUpdatesInfo` data to an approximate completion progress.
+/// Convert `LightUpdatesInfo` data to an approximate completion progress,
+/// and report it to both the terminal progress bar and the notification.
 /// TODO: Improve this and put it in the light module (independent of indicatif).
-fn lighting_progress_adapter(progress: &ProgressBar) -> impl FnMut(space::LightUpdatesInfo) + '_ {
+fn lighting_progress_adapter<'a>(
+    progress: &'a ProgressBar,
+    notif_rx: &'a Mutex<TryRecvKeep>,
+) -> impl FnMut(space::LightUpdatesInfo) + 'a {
+    // The queue length is not known in advance and grows as work is discovered, so treat the
+    // largest length seen so far as the denominator. Progress therefore never runs backwards,
+    // but it may stall while the queue is still growing.
     let mut worst = 1;
     move |info| {
         worst = worst.max(info.queue_count);
+        let done = worst - info.queue_count;
+
         progress.set_length(worst as u64);
-        progress.set_position((worst - info.queue_count) as u64);
+        progress.set_position(done as u64);
+
+        if let Some(notification) = notif_rx.lock().unwrap().try_borrow() {
+            notification.set_content(notification::NotificationContent::Progress {
+                title: literal!("Loading..."),
+                // `worst` is nonzero, so this is never a division by zero.
+                progress: ProgressBarState::new(done as f64 / worst as f64),
+                part: literal!("Computing light"),
+            });
+        }
     }
 }
 


### PR DESCRIPTION
The notification turns out to be destroyed rather than going stale. `notif_rx` is moved into the `yield_progress` callback, and universe construction consumes that callback. When the build returns the callback drops and takes the `Notification` with it, so `Receiver::read_content()` can no longer upgrade its `Weak`, `Hub::update()` discards it, and the VUI leaves `VuiPageState::Progress`. `--precompute-light` runs after that point, so it gets no progress display.

On `atrium` the progress page never appears at all. The build there is about 0.2 s, short enough that the notification is created and dropped between two hub polls, and lighting then runs about 2 s — so it's a 2.2 s load with no progress UI, rather than a bar that stops updating early. Counting `UI switched to ... (Progress)` in the trace log, three runs each of `--graphics headless --template atrium --seed 1 --precompute-light`:

```
before: 0/3 runs
after:  3/3 runs
```

This shares the notification through an `Arc` so it outlives construction, and reports light update progress to it alongside the `indicatif` bar.

It doesn't do the thing you described on the issue — hooking `indicatif` up to the notification hub so the application code isn't thinking about `indicatif` at all. That needs `Hub::primary_content()` to be reachable outside `all-is-cubes-ui`. Happy to go that way instead if you'd rather have the design change than the narrow fix; this is just the smaller one.

No closing keyword, since the design point in <https://github.com/kpreid/all-is-cubes/issues/495> stands either way.

`cargo xtask test`, `cargo xtask lint` and `cargo fmt --check` are clean.
